### PR TITLE
Lower required chars for tldr input

### DIFF
--- a/packages/prop-house-webapp/src/components/pages/Create/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Create/index.tsx
@@ -25,7 +25,7 @@ const isValidPropData = (data: ProposalFields) => {
   return (
     data.title.length > 5 &&
     data.what.length > 50 &&
-    data.tldr.length > 20 &&
+    data.tldr.length > 10 &&
     data.tldr.length < 120
   );
 };


### PR DESCRIPTION
Quick fix for users raising flags that "preview" button is broken. In reality, the new tldr input requires at least 20 chars which seems too long. Pushing temp fix for now. Real solution is better design.