### PR TITLE
Migration to remove vote type

### DIFF
--- a/packages/prop-house-backend/src/db/migrations/1652930687797-RemoveVoteType.ts
+++ b/packages/prop-house-backend/src/db/migrations/1652930687797-RemoveVoteType.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class RemoveVoteType1652930687797 implements MigrationInterface {
+    name = 'RemoveVoteType1652930687797'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "vote" DROP COLUMN "type"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "vote" ADD "type" integer NOT NULL`);
+    }
+
+}


### PR DESCRIPTION
This creates a migration that removes `type` from the Vote table