### PR TITLE
Add context to create proposal page title

### DIFF
--- a/packages/prop-house-webapp/src/components/pages/Create/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Create/index.tsx
@@ -13,7 +13,6 @@ import { useEthers } from '@usedapp/core';
 import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
 import isAuctionActive from '../../../utils/isAuctionActive';
 import { ProposalFields } from '../../../utils/proposalFields';
-import InspirationCard from '../../InspirationCard';
 import useWeb3Modal from '../../../hooks/useWeb3Modal';
 import Modal from '../../Modal';
 import removeTags from '../../../utils/removeTags';


### PR DESCRIPTION
Cleans up create proposal page:
- Remove inspiration card (doesn't apply to not strictly nounish houses)
- Adds context to title
