### PR TITLE
Fix proposal back button bug

### DIFF
--- a/packages/prop-house-webapp/src/components/pages/Proposal/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Proposal/index.tsx
@@ -16,6 +16,7 @@ import proposalFields from '../../../utils/proposalFields';
 import { IoArrowBackCircleOutline } from 'react-icons/io5';
 import LoadingIndicator from '../../LoadingIndicator';
 import { StoredProposalWithVotes } from '@nouns/prop-house-wrapper/dist/builders';
+import { nameToSlug } from '../../../utils/communitySlugs';
 
 const Proposal = () => {
   const params = useParams();
@@ -101,7 +102,7 @@ const Proposal = () => {
                 className={classes.backToAuction}
                 onClick={() => {
                   isEntryPoint && community
-                    ? navigate(`/${community?.contractAddress}`)
+                    ? navigate(`/${nameToSlug(community.name)}`)
                     : navigate(-1);
                 }}
               >


### PR DESCRIPTION
- Requires community to be loaded prior to enabling back button
- Uses community name as slug instead of contract address so that it loads correct community (if one community has several houses, it would load incorrect house)