### PR TITLE
LocalStorage for Vote Allotment

### DIFF
--- a/packages/prop-house-webapp/src/components/FullAuction/index.tsx
+++ b/packages/prop-house-webapp/src/components/FullAuction/index.tsx
@@ -113,7 +113,7 @@ const FullAuction: React.FC<{
 
   // save current community & vote allotment in local storage
   useEffect(() => {
-    localStorage.setItem('community', JSON.stringify(community));
+    community && localStorage.setItem('communityId', JSON.stringify(community.id));
     localStorage.setItem('votes', JSON.stringify(voteAllotments));
   }, [voteAllotments, community]);
 
@@ -182,18 +182,19 @@ const FullAuction: React.FC<{
     }
   };
 
-  const communityInStorage = JSON.parse(localStorage.getItem('community') || '{}');
+  const storageId = localStorage.getItem('communityId');
+  const storageIdParsed = storageId ? JSON.parse(storageId) : [];
 
   // if we go from one community to another we will clear the past community's vote allotment
   // and we'll set the new community as the current community to track it's vote allotment
   const clearVotesAndSetCommunity = () => {
     localStorage.removeItem('votes');
-    localStorage.removeItem('community');
-    localStorage.setItem('community', JSON.stringify(community));
+    localStorage.removeItem('communityId');
+    community && localStorage.setItem('communityId', JSON.stringify(community.id));
   };
 
   // check if we switch communities
-  community && communityInStorage.id !== community.id && clearVotesAndSetCommunity();
+  community && storageIdParsed !== community.id && clearVotesAndSetCommunity();
 
   return (
     <>


### PR DESCRIPTION
## As it stands
If you begin to vote for props but then click into one to read it, when you go back you'll lose all your allotted votes.

## What this PR fixed
We now save the `voteAllotments` object whenever it's updated via `handleVoteAllotment` in **localStorage** so if you've begun to vote and then expand a card or refresh the page your allotted votes are saved. However, when you leave the community, by either going Home or visiting another community page, your votes are cleared.
