### PR TITLE
Support Markdown in Proposal Card's TLDR

### DIFF
--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -68,7 +68,12 @@ const ProposalCard: React.FC<{
             <ReactMarkdown
               className={classes.truncatedTldr}
               children={proposal.tldr}
-              disallowedElements={['img']}
+              disallowedElements={['img', '']}
+              components={{
+                h1: 'p',
+                h2: 'p',
+                h3: 'p',
+              }}
             ></ReactMarkdown>
           )}
 


### PR DESCRIPTION
## As it stands
In the Card view (before expanding to the proposal page), any markdown added to the TLDR field was not being rendered. so if a user wrote `**My Cool Prop**` you would see the asteriks vs the stylized version: **My Cool Prop**. 

## What this PR fixes
I changed the `div` to a `<ReactMarkdown />` component to preserve the markdown styling.
<img width="327" alt="Screen Shot 2022-07-10 at 8 18 10 AM" src="https://user-images.githubusercontent.com/26611339/178144646-3729f1e5-1b10-40f3-b516-014d3aafee7c.png">


## Edge Cases
We should disallow images from being rendered in the Card view's TLDR field
<img width="664" alt="imgFix" src="https://user-images.githubusercontent.com/26611339/178144982-d2734b6d-1238-4179-adbb-8819d3d56262.png">

2) We changed heading tags to paragraph tags so they're rendered appropriately to space available (before/after below).
<img width="1175" alt="Screen Shot 2022-07-13 at 12 44 35 AM" src="https://user-images.githubusercontent.com/26611339/178652438-2b7ad5d8-5a62-4d15-be3a-d08c8d9c9629.png">

