### PR TITLE
Display "No Active Community" modal when navigating directly to Create page

### DIFF
--- a/packages/prop-house-webapp/src/App.tsx
+++ b/packages/prop-house-webapp/src/App.tsx
@@ -1,20 +1,21 @@
-import { Routes, Route } from "react-router-dom";
-import "bootstrap/dist/css/bootstrap.min.css";
-import "../src/css/globals.css";
-import { Suspense } from "react";
-import NavBar from "./components/NavBar";
-import Home from "./components/pages/Home";
-import Learn from "./components/pages/Learn";
-import Create from "./components/pages/Create";
-import Community from "./components/pages/Community";
-import Proposal from "./components/pages/Proposal";
-import Footer from "./components/Footer";
-import { Container } from "react-bootstrap";
-import "./App.css";
-import { Mainnet, DAppProvider, Config } from "@usedapp/core";
-import FAQ from "./components/pages/FAQ";
-import Explore from "./components/pages/Explore";
-import LoadingIndicator from "./components/LoadingIndicator";
+import { Routes, Route, useLocation } from 'react-router-dom';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import '../src/css/globals.css';
+import { Suspense, useEffect, useState } from 'react';
+import NavBar from './components/NavBar';
+import Home from './components/pages/Home';
+import Learn from './components/pages/Learn';
+import Create from './components/pages/Create';
+import Community from './components/pages/Community';
+import Proposal from './components/pages/Proposal';
+import Footer from './components/Footer';
+import { Container } from 'react-bootstrap';
+import './App.css';
+import { Mainnet, DAppProvider, Config } from '@usedapp/core';
+import FAQ from './components/pages/FAQ';
+import Explore from './components/pages/Explore';
+import LoadingIndicator from './components/LoadingIndicator';
+import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 
 const config: Config = {
   readOnlyChainId: Mainnet.chainId,
@@ -25,6 +26,17 @@ const config: Config = {
 };
 
 function App() {
+  const location = useLocation();
+  const [noActiveCommunity, setNoActiveCommunity] = useState(false);
+
+  useEffect(() => {
+    setNoActiveCommunity(false);
+
+    if (!location.state) {
+      setNoActiveCommunity(true);
+    }
+  }, [noActiveCommunity, location.state]);
+
   return (
     <DAppProvider config={config}>
       <Suspense fallback={<LoadingIndicator />}>
@@ -32,7 +44,14 @@ function App() {
           <NavBar />
           <Routes>
             <Route path="/" element={<Home />} />
-            <Route path="/create" element={<Create />} />
+            <Route
+              path="/create"
+              element={
+                <ProtectedRoute noActiveCommunity={noActiveCommunity}>
+                  <Create />
+                </ProtectedRoute>
+              }
+            />
             <Route path="/learn" element={<Learn />} />
             <Route path="/explore" element={<Explore />} />
             <Route path="/proposal/:id" element={<Proposal />} />

--- a/packages/prop-house-webapp/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/packages/prop-house-webapp/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from 'react-router-dom';
+import Button, { ButtonColor } from '../Button';
+import Modal from '../Modal';
+
+interface ProtectedRouteProps {
+  noActiveCommunity: boolean;
+  children: JSX.Element;
+}
+
+const ProtectedRoute = ({ noActiveCommunity, children }: ProtectedRouteProps) => {
+  const navigate = useNavigate();
+
+  const noActiveCommunityModalContent = {
+    title: 'No Active Community',
+    content: (
+      <>
+        <p>
+          Proposal creation can only be done via a community's page. Check for open funding rounds
+          on the homepage.
+        </p>
+        <Button text="Go Home" bgColor={ButtonColor.White} onClick={() => navigate(`/`)} />
+      </>
+    ),
+    onDismiss: () => navigate(`/`),
+  };
+
+  if (noActiveCommunity) {
+    return <Modal data={noActiveCommunityModalContent} />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
## As it stands
When a user navigates directly to [prop.house/create](https://prop.house/create) via the the search bar they will get a white screen app error because there's no `auction` or `activeCommunity` set. We don't know what community (or funding round) they're creating a proposal for. The intended path to get to the `/create` page is by clicking the `Propose` on a community page if there's an active round.

## Problem
We shouldn't let them land on a white screen. We should handle this error with some descriptive info and inform the user of what to do.

## What this PR fixes
Create a new component [`<ProtectedRoute />`](https://www.robinwieruch.de/react-router-private-routes/) to contionally handle navigating to the `/create` page when done directly. Instead of adding contionals to the Create page itself, our `ProtectedRoute` component receives the broswer's `location.state` and if there's no auction we show the user a new modal (shown below) that describes that they must access `/create` via a community page. If there's is an active auction/community it will render the proposal creation page as intended.

<img width="1004" alt="Screen Shot 2022-07-13 at 12 00 42 AM" src="https://user-images.githubusercontent.com/26611339/178647830-e2fb865c-a2ee-4143-82c6-bc7defbffa60.png">
 