### PR TITLE
Sort Proposals Newest to Oldest on homepage's 'Recent Proposals' section

### DIFF
--- a/packages/prop-house-webapp/src/components/PropCarousel/index.tsx
+++ b/packages/prop-house-webapp/src/components/PropCarousel/index.tsx
@@ -36,20 +36,23 @@ const PropCarousel = () => {
 
   const propCards =
     proposals &&
-    proposals.slice(0, 20).map((_, index) => {
-      return (
-        <div className={classes.propCardContainer} key={index}>
-          <ProposalCard proposal={proposals[index]} />
-        </div>
-      );
-    });
+    proposals
+      .sort((a, b) => (a.createdDate > b.createdDate ? -1 : 1))
+      .slice(0, 20)
+      .map((_, index) => {
+        return (
+          <div className={classes.propCardContainer} key={index}>
+            <ProposalCard proposal={proposals[index]} />
+          </div>
+        );
+      });
 
   return isLoading ? (
     <LoadingIndicator />
   ) : (
     <CarouselSection
-      contextTitle={t("browseProps")}
-      mainTitle={t("recentProps")}
+      contextTitle={t('browseProps')}
+      mainTitle={t('recentProps')}
       cards={propCards ? propCards : []}
     />
   );


### PR DESCRIPTION
This commit will sort the proposals from newest created first to oldest for displaying on homepage's 'Recent Proposals' section

<img width="764" alt="Screen Shot 2022-07-19 at 4 08 25 PM" src="https://user-images.githubusercontent.com/26611339/179839496-5b19a486-0da1-4b22-a8ac-ed3805f49e89.png">
