### PR TITLE
Prevent ETH symbol overflow on 3-digit amounts

### DIFF
--- a/packages/prop-house-webapp/src/components/ProfileHeader/ProfileHeader.module.css
+++ b/packages/prop-house-webapp/src/components/ProfileHeader/ProfileHeader.module.css
@@ -63,7 +63,7 @@
   margin-left: 0;
 }
 .propHouseDataRow > * {
-  margin: 0 2rem;
+  margin: 0 1.5rem;
 }
 
 .itemTitle {


### PR DESCRIPTION
This commit reduces the community data rows have half a rem to prevent the ETH symbol overflow on the Funded column when there's 3-digit amounts

## Before & After
![Screen Shot 2022-07-20 at 10 40 27 AM](https://user-images.githubusercontent.com/26611339/180010583-bbf256b4-0628-4939-a629-b05365e93d6d.png)

