### PR TITLE
Fix line clamping on mobile displays

### DIFF
--- a/packages/prop-house-webapp/src/components/ProfileHeader/ProfileHeader.module.css
+++ b/packages/prop-house-webapp/src/components/ProfileHeader/ProfileHeader.module.css
@@ -73,8 +73,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
-  line-clamp: 3;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
   -webkit-box-orient: vertical;
 }
 


### PR DESCRIPTION
Allow for 10 lines for the community description text on mobile instead of the same as desktop displays (3).