### PR TITLE
Remove community image hover state

### DIFF
--- a/packages/prop-house-webapp/src/components/CommunityCard/CommunityCard.module.css
+++ b/packages/prop-house-webapp/src/components/CommunityCard/CommunityCard.module.css
@@ -16,7 +16,3 @@
 .container {
   margin: 1rem 0;
 }
-.container img:hover {
-  cursor: pointer;
-  transform: scale(102%);
-}

--- a/packages/prop-house-webapp/src/components/CommunityCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/CommunityCard/index.tsx
@@ -1,22 +1,22 @@
-import classes from "./CommunityCard.module.css";
-import { Community } from "@nouns/prop-house-wrapper/dist/builders";
-import CommunityProfImg from "../CommunityProfImg";
-import { useTranslation } from "react-i18next";
+import classes from './CommunityCard.module.css';
+import { Community } from '@nouns/prop-house-wrapper/dist/builders';
+import CommunityProfImg from '../CommunityProfImg';
+import { useTranslation } from 'react-i18next';
 
 const CommunityCard: React.FC<{
   community: Community;
-}> = (props) => {
+}> = props => {
   const { community } = props;
   const { t } = useTranslation();
 
   return (
     <div className={classes.container}>
-      <CommunityProfImg community={community} />
+      <CommunityProfImg community={community} hover />
       <div className={classes.infoContainer}>
         <div className={classes.title}>{community.name}</div>
         <div className={classes.proposals}>
-          <span>{community.numProposals}</span>{" "}
-          {community.numProposals === 1 ? t("prop") : t("props")}
+          <span>{community.numProposals}</span>{' '}
+          {community.numProposals === 1 ? t('prop') : t('props')}
         </div>
       </div>
     </div>

--- a/packages/prop-house-webapp/src/components/CommunityProfImg/CommunityProfImg.module.css
+++ b/packages/prop-house-webapp/src/components/CommunityProfImg/CommunityProfImg.module.css
@@ -7,6 +7,11 @@
   cursor: default;
 }
 
+.hoverImg:hover {
+  transform: scale(102%);
+  cursor: pointer;
+}
+
 .loadingImg {
   background-color: rgb(230, 230, 230);
 }

--- a/packages/prop-house-webapp/src/components/CommunityProfImg/index.tsx
+++ b/packages/prop-house-webapp/src/components/CommunityProfImg/index.tsx
@@ -8,15 +8,16 @@ import { nameToSlug } from '../../utils/communitySlugs';
 const CommunityProfImg: React.FC<{
   community?: Community;
   inactiveTokenURI?: string;
-}> = (props) => {
-  const { community } = props;
+  hover?: boolean;
+}> = props => {
+  const { community, hover } = props;
 
   return community ? (
     <Link to={`/${nameToSlug(community.name)}`}>
       <img
         src={community.profileImageUrl}
         alt="community profile "
-        className={classes.img}
+        className={clsx(classes.img, hover && classes.hoverImg)}
       />
     </Link>
   ) : (


### PR DESCRIPTION
When you hover over a community's profile image it will not have hover styling and the cursor is reset to `default` vs `pointer`. Since there's no action to take by clicking it, we shouldn't show the user any micro-interaction.

On the `homepage` & `explore page` it will have a hover interaction since we can click it, but not on the community-specific internal page.