### PR TITLE
fix the the ENS truncation on proposal page

### DIFF
--- a/packages/prop-house-webapp/src/components/EthAddress/EthAddress.module.css
+++ b/packages/prop-house-webapp/src/components/EthAddress/EthAddress.module.css
@@ -7,8 +7,20 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  font-size: 14px;
 }
 
 .ethAddress a:visited {
   color: inherit;
+}
+
+.ethAddress a div {
+  min-width: 24px !important;
+}
+
+.truncate {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  display: block;
+  overflow: hidden;
 }

--- a/packages/prop-house-webapp/src/components/EthAddress/index.tsx
+++ b/packages/prop-house-webapp/src/components/EthAddress/index.tsx
@@ -1,24 +1,22 @@
-import clsx from "clsx";
-import React from "react";
-import { useAppSelector } from "../../hooks";
-import { useReverseENSLookUp } from "../../utils/ensLookup";
-import trimEthAddress from "../../utils/trimEthAddress";
-import classes from "./EthAddress.module.css";
-import Davatar from "@davatar/react";
-import { useEthers } from "@usedapp/core";
+import clsx from 'clsx';
+import React from 'react';
+import { useAppSelector } from '../../hooks';
+import { useReverseENSLookUp } from '../../utils/ensLookup';
+import trimEthAddress from '../../utils/trimEthAddress';
+import classes from './EthAddress.module.css';
+import Davatar from '@davatar/react';
+import { useEthers } from '@usedapp/core';
 
 const EthAddress: React.FC<{
   address: string;
+  truncate?: boolean;
   className?: string;
-}> = (props) => {
-  const { address } = props;
+}> = props => {
+  const { address, truncate } = props;
   const { library: provider } = useEthers();
 
-  const etherscanHost = useAppSelector(
-    (state) => state.configuration.etherscanHost
-  );
-  const buildAddressHref = (address: string) =>
-    [etherscanHost, "address", address].join("/");
+  const etherscanHost = useAppSelector(state => state.configuration.etherscanHost);
+  const buildAddressHref = (address: string) => [etherscanHost, 'address', address].join('/');
 
   const ens = useReverseENSLookUp(address);
 
@@ -28,14 +26,9 @@ const EthAddress: React.FC<{
       className={clsx(props.className, classes.ethAddress)}
     >
       <a href={buildAddressHref(address)} target="_blank" rel="noreferrer">
-        <Davatar
-          size={24}
-          address={address}
-          provider={provider}
-          generatedAvatarType="blockies"
-        />
+        <Davatar size={24} address={address} provider={provider} generatedAvatarType="blockies" />
 
-        <span className={classes.address}>
+        <span className={clsx(classes.address, truncate && classes.truncate)}>
           {ens ? ens : trimEthAddress(address)}
         </span>
       </a>

--- a/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
@@ -76,7 +76,7 @@
 
 .scoreCopy {
   font-weight: bold;
-  font-size: 15px;
+  font-size: 14px;
   color: var(--brand-gray);
 }
 .truncatedTldr {
@@ -93,6 +93,7 @@
   gap: 5px;
   width: 50%;
   justify-content: end;
+  height: 24px;
 }
 
 .titleContainer {
@@ -103,8 +104,4 @@
 }
 .address {
   width: 50%;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  display: block;
-  overflow: hidden;
 }

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -86,7 +86,7 @@ const ProposalCard: React.FC<{
               </div>
             ) : (
               <div className={classes.address}>
-                <EthAddress address={proposal.address} />
+                <EthAddress address={proposal.address} truncate />
               </div>
             )}
 


### PR DESCRIPTION
We were truncating the `EthAddress` component at a specific width which affects every instance of it. Not great.

We now have an optional trait (`truncate`) that can be passed to allow ENS truncation as well as creating two columns for the Card info in the bottom row.

<img width="317" alt="Screen Shot 2022-07-25 at 1 42 25 PM" src="https://user-images.githubusercontent.com/26611339/180841270-ecc0d0c6-d644-45e9-966f-a924111a576f.png">

