### PR TITLE
Stylize the Prop House logo

### DIFF
--- a/packages/prop-house-webapp/src/App.css
+++ b/packages/prop-house-webapp/src/App.css
@@ -1,40 +1,37 @@
 @font-face {
-	font-family: 'PT Root UI';
-	src:
-		url('./assets/fonts/PT-Root-UI_Bold.woff2') format('woff2'),
-		url('./assets/fonts/PT-Root-UI_Bold.woff') format('woff');
-	font-weight: bold;
-	font-style: normal;
+  font-family: 'PT Root UI';
+  src: url('./assets/fonts/PT-Root-UI_Bold.woff2') format('woff2'),
+    url('./assets/fonts/PT-Root-UI_Bold.woff') format('woff');
+  font-weight: bold;
+  font-style: normal;
 }
 
 @font-face {
-	font-family: 'PT Root UI';
-	src:
-		url('./assets/fonts/PT-Root-UI_Medium.woff2') format('woff2'),
-		url('./assets/fonts/PT-Root-UI_Medium.woff') format('woff');
-	font-weight: medium;
-	font-style: normal;
+  font-family: 'PT Root UI';
+  src: url('./assets/fonts/PT-Root-UI_Medium.woff2') format('woff2'),
+    url('./assets/fonts/PT-Root-UI_Medium.woff') format('woff');
+  font-weight: medium;
+  font-style: normal;
 }
 
 @font-face {
-	font-family: 'PT Root UI';
-	src:
-		url('./assets/fonts/PT-Root-UI_Regular.woff2') format('woff2'),
-		url('./assets/fonts/PT-Root-UI_Regular.woff') format('woff');
-	font-weight: normal;
-	font-style: normal;
+  font-family: 'PT Root UI';
+  src: url('./assets/fonts/PT-Root-UI_Regular.woff2') format('woff2'),
+    url('./assets/fonts/PT-Root-UI_Regular.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
 }
 
 @font-face {
-	font-family: 'PT Root UI';
-	src:
-		url('./assets/fonts/PT-Root-UI_Light.woff2') format('woff2'),
-		url('./assets/fonts/PT-Root-UI_Light.woff') format('woff');
-	font-weight: 300;
-	font-style: normal;
+  font-family: 'PT Root UI';
+  src: url('./assets/fonts/PT-Root-UI_Light.woff2') format('woff2'),
+    url('./assets/fonts/PT-Root-UI_Light.woff') format('woff');
+  font-weight: 300;
+  font-style: normal;
 }
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Londrina+Solid:wght@400;900&display=swap');
 
 * {
   font-family: 'PT Root UI';

--- a/packages/prop-house-webapp/src/components/NavBar/NavBar.module.css
+++ b/packages/prop-house-webapp/src/components/NavBar/NavBar.module.css
@@ -11,8 +11,20 @@
 .navbarBrand {
   color: var(--brand-black);
   font-weight: bold;
-  font-size: 22px;
+  font-size: 32px;
   text-decoration: none;
+}
+
+.navbarBrand span {
+  font-family: 'Londrina Solid';
+}
+
+.propText {
+  color: var(--brand-pink);
+}
+
+.houseText {
+  color: var(--brand-pink-semi-transparent);
 }
 
 .navbarBrand:hover {

--- a/packages/prop-house-webapp/src/components/NavBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/NavBar/index.tsx
@@ -13,25 +13,26 @@ const NavBar = () => {
     <Navbar bg="transparent" expand="lg" className={classes.navbar}>
       <Navbar.Brand>
         <Link to="/" className={classes.navbarBrand}>
-          {t("propHouse")}
+          <span className={classes.propText}>Prop</span>{' '}
+          <span className={classes.houseText}>House</span>
         </Link>
       </Navbar.Brand>
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav">
-        <Nav className={clsx("ms-auto", classes.navBarCollapse)}>
+        <Nav className={clsx('ms-auto', classes.navBarCollapse)}>
           <Nav.Link as="div">
             <Link to="/learn" className={classes.link}>
-              {t("learn")}
+              {t('learn')}
             </Link>
           </Nav.Link>
           <Nav.Link as="div">
             <Link to={`/explore`} className={classes.link}>
-              {t("explore")}
+              {t('explore')}
             </Link>
           </Nav.Link>
           <Nav.Link as="div">
             <Link to="/faq" className={classes.link}>
-              {t("faq")}
+              {t('faq')}
             </Link>
           </Nav.Link>
 


### PR DESCRIPTION
Created a stylized version of the logo. Added the Londrina Solid font and gave it the PH colors.

## Desktop
<img width="417" alt="Screen Shot 2022-07-25 at 3 52 15 PM" src="https://user-images.githubusercontent.com/26611339/180862762-bbee43f3-f1a0-4428-bfe4-e7d7bf042e10.png">

## Mobile
<img width="499" alt="Screen Shot 2022-07-25 at 3 55 31 PM" src="https://user-images.githubusercontent.com/26611339/180863317-90ecc3e0-c068-42a3-a652-66a700062eb6.png">

