### PR TITLE
Sort props randomly by default

### DIFF
--- a/packages/prop-house-webapp/src/components/FullAuction/index.tsx
+++ b/packages/prop-house-webapp/src/components/FullAuction/index.tsx
@@ -102,9 +102,13 @@ const FullAuction: React.FC<{
     const fetchAuctionProposals = async () => {
       const proposals = await client.current.getAuctionProposals(auction.id);
       dispatch(setActiveProposals(proposals));
-      const auctionEnded = auctionStatus(auction) === AuctionStatus.AuctionEnded;
 
-      dispatchSortProposals(dispatch, auctionEnded ? SortType.Score : SortType.CreatedAt, false); // initial sort
+      // default sorting method is random, unless the auction is over, in which case its by votes
+      dispatchSortProposals(
+        dispatch,
+        auctionStatus(auction) === AuctionStatus.AuctionEnded ? SortType.Score : SortType.Random,
+        false,
+      );
     };
     fetchAuctionProposals();
     return () => {

--- a/packages/prop-house-webapp/src/components/SortToggles/index.tsx
+++ b/packages/prop-house-webapp/src/components/SortToggles/index.tsx
@@ -18,8 +18,8 @@ const SortToggles: React.FC<{
   const auctionVoting = auctionStatus(auction) === AuctionStatus.AuctionVoting;
   const allowSortByVotes = auctionVoting || auctionEnded;
 
-  const [datesSorted, setDatesSorted] = useState(auctionEnded ? false : true);
-  const [dateAscending, setDateAscending] = useState(auctionEnded ? false : true);
+  const [datesSorted, setDatesSorted] = useState(false);
+  const [dateAscending, setDateAscending] = useState(false);
   const [votesSorted, setVotesSorted] = useState(auctionEnded ? true : false);
   const [votesAscending, setVotesAscending] = useState(auctionEnded ? true : false);
 

--- a/packages/prop-house-webapp/src/utils/sortingProposals.ts
+++ b/packages/prop-house-webapp/src/utils/sortingProposals.ts
@@ -11,15 +11,28 @@ export interface SortProps {
 export enum SortType {
   Score,
   CreatedAt,
+  Random,
 }
 
 export const _sortProps = (proposals: StoredProposalWithVotes[], props: SortProps) => {
-  return proposals.sort((a, b) =>
-    props.sortType === SortType.CreatedAt
-      ? sortHelper(dayjs(a.createdDate), dayjs(b.createdDate), props.ascending)
-      : sortHelper(Number(a.score), Number(b.score), props.ascending),
-  );
+  switch (props.sortType) {
+    case SortType.Score:
+      return proposals.sort((a, b) =>
+        sortHelper(Number(a.score), Number(b.score), props.ascending),
+      );
+    case SortType.Random:
+      return proposals.sort(() => Math.random() - 0.5);
+    case SortType.CreatedAt:
+      return proposals.sort((a, b) =>
+        sortHelper(dayjs(a.createdDate), dayjs(b.createdDate), props.ascending),
+      );
+    default:
+      return proposals.sort((a, b) =>
+        sortHelper(dayjs(a.createdDate), dayjs(b.createdDate), props.ascending),
+      );
+  }
 };
+
 export const sortHelper = (a: any, b: any, ascending: boolean) => {
   return ascending ? (a < b ? -1 : 1) : a < b ? 1 : -1;
 };


### PR DESCRIPTION
## Before this PR
The default sorting method was by the proposals created date. However that meant that as new proposals came in, the early props would get "pushed down" and potentially get less views as the number of proposals grew. We've noticed people waiting until the end to submit their proposals in order to be near the top. We can mitigate this by randomizing the order in which they're displayed.

## The Fix
Now the default sorting method is random. We will see that both toggles are unchecked, but when you click one it will override the random sorting and re-order the props in an opinionated method. On page refresh it will go back to random because there's no need store the sortBy method in local storage

## Statuses & Sorting Methods
- **Proposal:** Random
- **Voting:** Random
- **Ended:** Votes (descending)