### PR TITLE
Add voting strategy for OCM and Karma communities

### DIFF
--- a/packages/prop-house-communities/src/communities/contracts.ts
+++ b/packages/prop-house-communities/src/communities/contracts.ts
@@ -2,6 +2,33 @@ import { client } from '../subgraph/client';
 import { nounsDelegatedVotesToAddressQuery } from '../subgraph/nounsQuery';
 import { gql } from '@apollo/client';
 import { Contract } from './types';
+import { ethers } from 'ethers';
+import BalanceOfABI from '../abi/BalanceOfABI.json';
+import { Provider } from '@ethersproject/providers';
+
+/**
+ * Strategy for OnchainMonkey and KarmaMonkey communities. Uses sum of `balanceOf` from each community.
+ */
+const onChainMonkeyStrategy = async (
+  userAddress: string,
+  provider: Provider,
+  commmunityAddress: string,
+) => {
+  const karmaMonkeyAddress = '0x86cc280d0bac0bd4ea38ba7d31e895aa20cceb4b';
+  const ocmMonkeyAddress = '0x960b7a6bcd451c9968473f7bbfd9be826efd549a';
+
+  const karmaContract = new ethers.Contract(karmaMonkeyAddress, BalanceOfABI, provider);
+  const ocmContract = new ethers.Contract(ocmMonkeyAddress, BalanceOfABI, provider);
+
+  try {
+    const karmaVotes = await karmaContract.balanceOf(userAddress);
+    const ocmVotes = await ocmContract.balanceOf(userAddress);
+    return ethers.BigNumber.from(karmaVotes).add(ethers.BigNumber.from(ocmVotes)).toNumber();
+  } catch (e) {
+    console.log(`error counting votes community: ${commmunityAddress}: ${e}`);
+    return 0;
+  }
+};
 
 /**
  * Contracts of communities that an alternative appraoch to a `balanceOf` call to calculate votes.
@@ -17,5 +44,17 @@ export const contracts: Contract[] = [
       return result.data.delegates[0] ? result.data.delegates[0].delegatedVotesRaw : 0;
     },
     multiplier: 10,
+  },
+  {
+    address: '0x960b7a6bcd451c9968473f7bbfd9be826efd549a',
+    numVotes: async (userAddress: string, provider, commmunityAddress) => {
+      return await onChainMonkeyStrategy(userAddress, provider, commmunityAddress);
+    },
+  },
+  {
+    address: '0x86cc280d0bac0bd4ea38ba7d31e895aa20cceb4b',
+    numVotes: async (userAddress: string, provider, commmunityAddress) => {
+      return await onChainMonkeyStrategy(userAddress, provider, commmunityAddress);
+    },
   },
 ];

--- a/packages/prop-house-communities/src/communities/types.ts
+++ b/packages/prop-house-communities/src/communities/types.ts
@@ -1,9 +1,11 @@
+import { Provider } from '@ethersproject/providers';
+
 /**
  * Contract for communities that required alt approaches to counting votes (other than the default `balanceOf` call)
  */
 export interface Contract {
   address: string;
-  numVotes: (userAddress: string) => Promise<number>;
+  numVotes: (userAddress: string, provider: Provider, commmunityAddress: string) => Promise<number>;
   /** [optional] multiplier of votes. number to be used against default number of votes (e.g. make each nft count as 10 votes instead of 1) */
   multiplier?: number;
 }

--- a/packages/prop-house-communities/src/utils/getNumVotes.ts
+++ b/packages/prop-house-communities/src/utils/getNumVotes.ts
@@ -23,7 +23,7 @@ export const getNumVotes = async (
   // check if community has alt approach to fetching votes
   const altCommunity = getAltCommunity(commmunityAddress);
   if (altCommunity) {
-    const votes = await altCommunity.numVotes(userAddress);
+    const votes = await altCommunity.numVotes(userAddress, provider, commmunityAddress);
     return altCommunity.multiplier ? votes * altCommunity.multiplier : votes;
   }
 


### PR DESCRIPTION
From linear: https://linear.app/prophouse/issue/PROP-168/add-ocm-custom-vote-count

Onchain Monkey founders reached out about using Prop House. Their community is compromised of two collections ([onchainmonkey](https://opensea.io/collection/onchainmonkey) and [karma-monkey](https://opensea.io/collection/karma-monkey)). In order for this to work, they need their house to be able to count up votes from both communities. As such, we need a new custom function in prop-house-communities to be able to use `balanceOf` from both collections. 

Can be tested against by manually passing an OCM/KM holder address into the `prop-house-communities` `getNumVotes` func. House to test against once merged: https://master--prop-house.netlify.app/ocm-and-karma-monkeys

Note: they are aware of the snapshot transition and that with current setup, it is possible to cheat the system.
