### PR TITLE
Prop-174-fix-ocm-issue-with-vote-calculation

### DIFF
--- a/packages/prop-house-webapp/src/utils/aggVoteWeight.ts
+++ b/packages/prop-house-webapp/src/utils/aggVoteWeight.ts
@@ -12,5 +12,5 @@ export const aggVoteWeightForProps = (proposals: StoredProposalWithVotes[], addr
  */
 export const aggVoteWeightForProp = (votes: StoredVote[], proposalId: number) =>
   votes
-    .filter((v) => v.proposalId === proposalId)
-    .reduce((agg, current) => agg + current.weight, 0);
+    .filter(v => v.proposalId === proposalId)
+    .reduce((agg, current) => Number(agg) + Number(current.weight), 0);


### PR DESCRIPTION
Fixes bug where vote calculation variables were being added as strings. e.g. "5" + "10" = "510". When casted to number type, it would turn out to be 510 instead of the supposed 15 (5 + 10). 