### PR TITLE
Fix bug: counting votes

### DIFF
--- a/packages/prop-house-backend/src/proposal/proposal.entity.ts
+++ b/packages/prop-house-backend/src/proposal/proposal.entity.ts
@@ -56,7 +56,9 @@ export class Proposal extends SignedEntity {
 
   @BeforeUpdate()
   updateScore() {
-    this.score = this.votes.reduce((acc, vote) => acc + vote.weight, 0);
+    this.score = this.votes.reduce((acc, vote) => {
+      return Number(acc) + Number(vote.weight);
+    }, 0);
   }
 
   @Column()

--- a/packages/prop-house-backend/src/vote/votes.controller.ts
+++ b/packages/prop-house-backend/src/vote/votes.controller.ts
@@ -91,7 +91,7 @@ export class VotesController {
     // Voting up
     if (createVoteDto.direction === VoteDirections.Up) {
       const aggVoteWeightSubmitted = signerVotesForAuction.reduce(
-        (agg, current) => agg + current.weight,
+        (agg, current) => Number(agg) + Number(current.weight),
         0,
       );
 

--- a/packages/prop-house-webapp/src/components/FullAuction/index.tsx
+++ b/packages/prop-house-webapp/src/components/FullAuction/index.tsx
@@ -64,7 +64,7 @@ const FullAuction: React.FC<{
 
   // total votes allotted (these are pre-submitted votes)
   const numAllottedVotes = voteAllotments.reduce(
-    (counter, allotment) => counter + allotment.votes,
+    (counter, allotment) => Number(counter) + Number(allotment.votes),
     0,
   );
 

--- a/packages/prop-house-webapp/src/utils/aggVoteWeight.ts
+++ b/packages/prop-house-webapp/src/utils/aggVoteWeight.ts
@@ -5,7 +5,10 @@ import extractAllVotes from './extractAllVotes';
  * Calculates aggregate vote weight for votes extracted from a set of proposals
  */
 export const aggVoteWeightForProps = (proposals: StoredProposalWithVotes[], address: string) =>
-  extractAllVotes(proposals, address).reduce((agg, current) => agg + current.weight, 0);
+  extractAllVotes(proposals, address).reduce(
+    (agg, current) => Number(agg) + Number(current.weight),
+    0,
+  );
 
 /**
  * Calculates aggregate vote weight for a specific proposals from a set of votes


### PR DESCRIPTION
A few of the functions used to count votes (e.g. counting up votes for proposals, counting up total votes for user, etc) are being miscounted due to the fn reading numbers as strings:
```
    this.score = this.votes.reduce((acc, vote) => {
      return acc + vote.weight;
    }, 0);
```
even though `acc` and `vote.weight` are both assumed to be of `number` type, they are being read as strings. as such, `0` + `1` = `01` , `01` + `1` = `011`, etc.

I'm casting the params as Numbers to ensure they are processed in the correct type.
```
    this.score = this.votes.reduce((acc, vote) => {
      return Number(acc) + Number(vote.weight);
    }, 0);
```
