### PR TITLE
Add description property to auction entity

### DIFF
--- a/packages/prop-house-backend/src/auction/auction.entity.ts
+++ b/packages/prop-house-backend/src/auction/auction.entity.ts
@@ -37,6 +37,9 @@ export class Auction {
   @Column({ nullable: true })
   currencyType: string;
 
+  @Column({ nullable: true })
+  description: string;
+
   @Column()
   numWinners: number;
 

--- a/packages/prop-house-backend/src/db/migrations/1660927829924-AddAuctionDescription.ts
+++ b/packages/prop-house-backend/src/db/migrations/1660927829924-AddAuctionDescription.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddAuctionDescription1660927829924 implements MigrationInterface {
+    name = 'AddAuctionDescription1660927829924'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "auction" ADD "description" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "auction" DROP COLUMN "description"`);
+    }
+
+}

--- a/packages/prop-house-wrapper/src/builders.ts
+++ b/packages/prop-house-wrapper/src/builders.ts
@@ -47,6 +47,7 @@ export class Auction extends Signable {
     public readonly currencyType: string,
     public readonly numWinners: number,
     public readonly community: number,
+    public readonly description: string,
   ) {
     super();
   }
@@ -62,6 +63,7 @@ export class Auction extends Signable {
       currencyType: this.currencyType,
       numWinners: this.numWinners,
       community: this.community,
+      description: this.description,
     };
   }
 }


### PR DESCRIPTION
- Adds `description` property to `auction` entity so that new multi-round UI PRs can consume it.
- Branches off of #163 so that new migration files are accounted for.