### PR TITLE
change house filters to 'active' & 'all rounds'

### DIFF
--- a/packages/prop-house-webapp/src/components/HouseUtilityBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/HouseUtilityBar/index.tsx
@@ -14,7 +14,7 @@ const HouseUtilityBar: React.FC<{
     props;
 
   const handleSearchInputChange = (e: any) => {
-    if (currentRoundStatus !== RoundStatus.AllRounds) setCurrentRoundStatus(RoundStatus.AllRounds);
+    if (currentRoundStatus !== RoundStatus.Active) setCurrentRoundStatus(RoundStatus.Active);
     setInput(e.target.value);
   };
 

--- a/packages/prop-house-webapp/src/components/StatusFilters/index.tsx
+++ b/packages/prop-house-webapp/src/components/StatusFilters/index.tsx
@@ -6,6 +6,7 @@ import classes from './StatusFilters.module.css';
 
 // We aren't using AuctionStatus enum becuase AuctionStatus[0] is 'not started' and we don't filter by 'not started', rather RoundStatus[0] is the default 'all rounds'
 export enum RoundStatus {
+  Active,
   AllRounds,
   Proposing,
   Voting,
@@ -20,23 +21,13 @@ export interface Status {
 
 const statuses: Status[] = [
   {
-    status: RoundStatus.AllRounds,
-    title: 'All rounds',
+    status: RoundStatus.Active,
+    title: 'Active',
     bgColor: classes.pink,
   },
   {
-    status: RoundStatus.Proposing,
-    title: 'Proposing',
-    bgColor: classes.green,
-  },
-  {
-    status: RoundStatus.Voting,
-    title: 'Voting',
-    bgColor: classes.purple,
-  },
-  {
-    status: RoundStatus.Ended,
-    title: 'Ended',
+    status: RoundStatus.AllRounds,
+    title: 'All rounds',
     bgColor: classes.black,
   },
 ];


### PR DESCRIPTION
On the House page, we now have only 2 filter methods: `Active` & `All Rounds`.

`Active` encompasses rounds with either `Proposing` or `Voting` status.

If there's no `Active` status rounds, the default method will be `All Rounds`.