### PR TITLE
Fix back button when proposal page is entry point

### DIFF
--- a/packages/prop-house-backend/src/community/community.controller.ts
+++ b/packages/prop-house-backend/src/community/community.controller.ts
@@ -34,11 +34,11 @@ export class CommunitiesController {
   }
 
   @Get('communities/id/:id')
-  async findOne(@Param('id') id: number): Promise<ExtendedCommunity> {
+  async findOne(@Param('id') id: number): Promise<Community> {
     const foundCommunity = await this.communitiesService.findOne(id);
     if (!foundCommunity)
       throw new HttpException('Community not found', HttpStatus.NOT_FOUND);
-    return buildExtendedCommunity(foundCommunity);
+    return foundCommunity;
   }
 
   @Get('communities/name/:name')

--- a/packages/prop-house-webapp/src/components/PropCardsAndModules/index.tsx
+++ b/packages/prop-house-webapp/src/components/PropCardsAndModules/index.tsx
@@ -1,5 +1,5 @@
 import {
-  CommunityWithAuctions,
+  Community,
   StoredAuction,
   StoredProposalWithVotes,
 } from '@nouns/prop-house-wrapper/dist/builders';
@@ -29,7 +29,7 @@ import { voteWeightForAllottedVotes } from '../../utils/voteWeightForAllottedVot
 
 const PropCardsAndModules: React.FC<{
   auction: StoredAuction;
-  community: CommunityWithAuctions;
+  community: Community;
   setShowVotingModal: Dispatch<SetStateAction<boolean>>;
 }> = props => {
   const { auction, community, setShowVotingModal } = props;

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -14,18 +14,22 @@ import { cmdPlusClicked } from '../../utils/cmdPlusClicked';
 import { useEthers } from '@usedapp/core';
 import { openInNewTab } from '../../utils/openInNewTab';
 import VotesDisplay from '../VotesDisplay';
+import { useAppSelector } from '../../hooks';
+import { nameToSlug } from '../../utils/communitySlugs';
 
 const ProposalCard: React.FC<{
   proposal: StoredProposalWithVotes;
   auctionStatus: AuctionStatus;
   cardStatus: ProposalCardStatus;
-  fromHome?: boolean;
   winner?: boolean;
 }> = props => {
-  const { proposal, auctionStatus, cardStatus, fromHome, winner } = props;
+  const { proposal, auctionStatus, cardStatus, winner } = props;
 
   const { account } = useEthers();
   let navigate = useNavigate();
+
+  const community = useAppSelector(state => state.propHouse.activeCommunity);
+  const round = useAppSelector(state => state.propHouse.activeRound);
 
   const roundIsVotingOrOver = () =>
     auctionStatus === AuctionStatus.AuctionVoting || auctionStatus === AuctionStatus.AuctionEnded;
@@ -35,11 +39,13 @@ const ProposalCard: React.FC<{
     <>
       <div
         onClick={e => {
+          if (!community || !round) return;
+
           if (cmdPlusClicked(e)) {
-            openInNewTab(`${fromHome ? `proposal/${proposal.id}` : proposal.id}`);
+            openInNewTab(`${nameToSlug(round.title)}/${proposal.id}`);
             return;
           }
-          navigate(`${fromHome ? `proposal/${proposal.id}` : proposal.id}`);
+          navigate(`${proposal.id}`);
         }}
       >
         <Card

--- a/packages/prop-house-webapp/src/components/RoundModules/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundModules/index.tsx
@@ -1,5 +1,5 @@
 import {
-  CommunityWithAuctions,
+  Community,
   StoredAuction,
   StoredProposalWithVotes,
 } from '@nouns/prop-house-wrapper/dist/builders';
@@ -24,7 +24,7 @@ import { voteWeightForAllottedVotes } from '../../utils/voteWeightForAllottedVot
 
 const RoundModules: React.FC<{
   auction: StoredAuction;
-  community: CommunityWithAuctions;
+  community: Community;
   setShowVotingModal: Dispatch<SetStateAction<boolean>>;
 }> = props => {
   const { auction, community, setShowVotingModal } = props;

--- a/packages/prop-house-webapp/src/components/pages/Proposal/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Proposal/index.tsx
@@ -1,38 +1,44 @@
 import classes from './Proposal.module.css';
 import { useParams } from 'react-router';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAppSelector } from '../../../hooks';
 import NotFound from '../../NotFound';
 import { useEffect, useRef, useState } from 'react';
 import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
 import { useEthers } from '@usedapp/core';
 import { useDispatch } from 'react-redux';
-import { setActiveCommunity, setActiveProposal } from '../../../state/slices/propHouse';
+import {
+  setActiveCommunity,
+  setActiveProposal,
+  setActiveRound,
+} from '../../../state/slices/propHouse';
 import RenderedProposalFields from '../../RenderedProposalFields';
 import proposalFields from '../../../utils/proposalFields';
 import { IoArrowBackCircleOutline } from 'react-icons/io5';
 import LoadingIndicator from '../../LoadingIndicator';
 import { StoredProposalWithVotes } from '@nouns/prop-house-wrapper/dist/builders';
-import { nameToSlug } from '../../../utils/communitySlugs';
 import { Container } from 'react-bootstrap';
-import buildRoundPath from '../../../utils/buildRoundPath';
+import { buildRoundPath } from '../../../utils/buildRoundPath';
 
 const Proposal = () => {
   const params = useParams();
   const { id } = params;
-
+  const { library: provider } = useEthers();
   const navigate = useNavigate();
-  const location = useLocation();
-  const isEntryPoint = !location.state?.fromRoundPage;
+
+  const [failedFetch, setFailedFetch] = useState(false);
 
   const dispatch = useDispatch();
-  const [failedFetch, setFailedFetch] = useState(false);
   const proposal = useAppSelector(state => state.propHouse.activeProposal);
   const community = useAppSelector(state => state.propHouse.activeCommunity);
+  const round = useAppSelector(state => state.propHouse.activeRound);
   const backendHost = useAppSelector(state => state.configuration.backendHost);
-  const { library: provider } = useEthers();
   const backendClient = useRef(new PropHouseWrapper(backendHost, provider?.getSigner()));
-  const { title: roundTitle } = useParams();
+
+  const handleBackClick = () => {
+    if (!community || !round) return;
+    navigate(buildRoundPath(community, round), { replace: false });
+  };
 
   useEffect(() => {
     backendClient.current = new PropHouseWrapper(backendHost, provider?.getSigner());
@@ -62,20 +68,20 @@ const Proposal = () => {
   }, [id, dispatch, failedFetch]);
 
   /**
-   * when /proposal/:id is entry point, community is not yet
+   * when page is entry point, community and round are not yet
    * avail for back button so it has to be fetched.
    */
   useEffect(() => {
-    if (community || !proposal || !proposal.auctionId) return;
-
+    if (!proposal) return;
     const fetchCommunity = async () => {
-      const auction = await backendClient.current.getAuction(proposal.auctionId);
-      const community = await backendClient.current.getCommunityWithId(auction.community);
+      const round = await backendClient.current.getAuction(proposal.auctionId);
+      const community = await backendClient.current.getCommunityWithId(round.community);
       dispatch(setActiveCommunity(community));
+      dispatch(setActiveRound(round));
     };
 
     fetchCommunity();
-  }, [id, dispatch, proposal, community]);
+  }, [id, dispatch, proposal]);
 
   return (
     <>
@@ -88,18 +94,7 @@ const Proposal = () => {
               proposalId={proposal.id}
               community={community}
               backButton={
-                <div
-                  className={classes.backToAuction}
-                  onClick={() => {
-                    isEntryPoint && community
-                      ? navigate(
-                          `/${nameToSlug(community.name)}/${
-                            roundTitle ? buildRoundPath(community, roundTitle) : ''
-                          }`,
-                        )
-                      : navigate(-1);
-                  }}
-                >
+                <div className={classes.backToAuction} onClick={() => handleBackClick()}>
                   <IoArrowBackCircleOutline size={'1.5rem'} />
                   <span>Back</span>
                 </div>

--- a/packages/prop-house-webapp/src/state/slices/propHouse.ts
+++ b/packages/prop-house-webapp/src/state/slices/propHouse.ts
@@ -1,7 +1,7 @@
 import {
   StoredAuction,
   StoredProposalWithVotes,
-  CommunityWithAuctions,
+  Community,
 } from '@nouns/prop-house-wrapper/dist/builders';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { SortProps, SortType, _sortProps } from '../../utils/sortingProposals';
@@ -10,7 +10,7 @@ export interface PropHouseSlice {
   activeRound?: StoredAuction;
   activeProposal?: StoredProposalWithVotes;
   activeProposals?: StoredProposalWithVotes[];
-  activeCommunity?: CommunityWithAuctions;
+  activeCommunity?: Community;
 }
 
 const initialState: PropHouseSlice = {};
@@ -38,7 +38,7 @@ export const propHouseSlice = createSlice({
       if (!state.activeProposals) return;
       state.activeProposals = _sortProps(state.activeProposals, action.payload);
     },
-    setActiveCommunity: (state, action: PayloadAction<CommunityWithAuctions | undefined>) => {
+    setActiveCommunity: (state, action: PayloadAction<Community | undefined>) => {
       state.activeCommunity = action.payload;
     },
   },

--- a/packages/prop-house-webapp/src/utils/buildRoundPath.ts
+++ b/packages/prop-house-webapp/src/utils/buildRoundPath.ts
@@ -1,17 +1,8 @@
-import { CommunityWithAuctions } from '@nouns/prop-house-wrapper/dist/builders';
+import { Auction, Community } from '@nouns/prop-house-wrapper/dist/builders';
 import { nameToSlug } from './communitySlugs';
 
 /**
- * when /:house/:round/:id is the entry point, the round is not yet
- * avail for back button so it has to be fetched.
+ * build url path to round (/:community-name/:round-name)
  */
-const buildRoundPath = (community: CommunityWithAuctions, roundTitle: string) => {
-  const round = community.auctions.filter(
-    r => nameToSlug(r.title.toString()) === nameToSlug(roundTitle),
-  );
-
-  const path = nameToSlug(round[0].title);
-  return path;
-};
-
-export default buildRoundPath;
+export const buildRoundPath = (community: Community, round: Auction) =>
+  `/${nameToSlug(community.name)}/${nameToSlug(round.title)}`;

--- a/packages/prop-house-wrapper/src/index.ts
+++ b/packages/prop-house-wrapper/src/index.ts
@@ -8,6 +8,7 @@ import {
   StoredFile,
   StoredVote,
   Vote,
+  Community,
   CommunityWithAuctions,
 } from './builders';
 import FormData from 'form-data';
@@ -220,7 +221,7 @@ export class PropHouseWrapper {
     }
   }
 
-  async getCommunityWithId(id: number): Promise<CommunityWithAuctions> {
+  async getCommunityWithId(id: number): Promise<Community> {
     try {
       return (await axios.get(`${this.host}/communities/id/${id}`)).data;
     } catch (e: any) {


### PR DESCRIPTION
- Refactors state management so that when the user arrives in the proposal page first, we fetch community and round to be able to redirect "back" to the corresponding round page.
- Fixes `cmd + click` from round page