### PR TITLE
Add  3-Clause BSD License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
 BSD 3-Clause License
 
+Copyright 2022 Prop House Team
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
@@ -10,7 +12,7 @@ modification, are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
 
-3. Neither the name of the copyright holder nor the names of its
+3. Neither the name of the copyright holder nor the names of itsCopyright <YEAR> <COPYRIGHT HOLDER>
    contributors may be used to endorse or promote products derived from
    this software without specific prior written permission.
 


### PR DESCRIPTION
the [original copy](https://opensource.org/licenses/BSD-3-Clause) has a copyright line at the very top:
```
Copyright <YEAR> <COPYRIGHT HOLDER>
```

should it be included? (current commit removes it)

