### PR TITLE
Update Proposal Page Colors And Back Button

### DIFF
--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/RenderedProposalFields.module.css
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/RenderedProposalFields.module.css
@@ -58,6 +58,9 @@ hr {
 .subinfo a {
   font-weight: 650;
 }
+.propSubmissionData {
+  display: flex;
+}
 @media (max-width: 577px) {
   .propSpacer {
     display: none !important;
@@ -69,6 +72,11 @@ hr {
   color: var(--brand-black);
   font-weight: 700;
   font-size: 1rem;
+  gap: 5px;
+}
+
+.textSpacer {
+  padding: 0px 5px;
 }
 
 .markdown a {

--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/RenderedProposalFields.module.css
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/RenderedProposalFields.module.css
@@ -9,7 +9,7 @@
 
 @media (min-width: 577px) {
   .headerContainer {
-    flex-direction: row;
+    flex-direction: column;
     gap: 20px;
   }
 }
@@ -20,14 +20,12 @@
 .previewCol img {
   max-width: 100%;
 }
-.previewCol a {
-  text-decoration: underline !important;
-}
+
 .previewCol h2 {
-  margin-top: 3rem;
+  margin-top: 2rem;
   font-size: 18px;
   font-weight: 600;
-  color: var(--brand-gray);
+  color: var(--brand-black);
 }
 
 .previewCol p {
@@ -36,7 +34,7 @@
 }
 
 hr {
-  background-color: var(--brand-gray);
+  background-color: var(--brand-gray-semi-transparent);
 }
 
 .subinfo {
@@ -44,11 +42,8 @@ hr {
   color: var(--brand-black);
   font-weight: 700;
   flex-direction: row;
-  padding-bottom: 5px;
 }
-.propNumber {
-  color: black;
-}
+
 @media (max-width: 577px) {
   .subinfo {
     flex-direction: column;
@@ -58,6 +53,7 @@ hr {
 .subinfo a {
   font-weight: 650;
 }
+
 .propSubmissionData {
   display: flex;
 }
@@ -69,7 +65,7 @@ hr {
 .submittedBy {
   display: flex;
   align-items: flex-end;
-  color: var(--brand-black);
+  color: var(--brand-pink);
   font-weight: 700;
   font-size: 1rem;
   gap: 5px;
@@ -91,6 +87,8 @@ hr {
 .communityAndPropNumber {
   display: flex;
   align-items: center;
+  color: var(--brand-gray) !important;
+  gap: 5px;
 }
 
 .communityProfImgContainer {
@@ -103,4 +101,16 @@ hr {
   height: 24px;
   border-radius: 24px;
   margin-right: 4px;
+}
+.backBtnContainer {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  font-weight: 700;
+  color: var(--brand-gray);
+}
+@media (max-width: 577px) {
+  .backBtnContainer {
+    padding-bottom: 25px;
+  }
 }

--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
@@ -15,10 +15,11 @@ export interface RenderedProposalProps {
   proposalId?: number;
   backButton?: React.ReactNode;
   community?: any;
+  roundName?: string;
 }
 
 const RenderedProposalFields: React.FC<RenderedProposalProps> = props => {
-  const { fields, address, proposalId, backButton, community } = props;
+  const { fields, address, proposalId, backButton, community, roundName } = props;
   const { t } = useTranslation();
 
   return (
@@ -26,36 +27,34 @@ const RenderedProposalFields: React.FC<RenderedProposalProps> = props => {
       <Row>
         <Col xl={12} className={classes.previewCol}>
           <div className={classes.headerContainer}>
-            {backButton && backButton}
+            <div className={classes.backBtnContainer}>
+              {backButton && backButton}
+
+              {community && roundName && (
+                <Link
+                  to={`/${nameToSlug(community.name)}`}
+                  className={classes.communityProfImgContainer}
+                >
+                  {community.name.charAt(0).toUpperCase() + community.name.slice(1)} House:{' '}
+                  {roundName}
+                </Link>
+              )}
+            </div>
 
             <div>
               {address && proposalId && (
                 <div className={classes.subinfo}>
                   <div className={classes.communityAndPropNumber}>
                     <span className={classes.propNumber}>Prop #{proposalId} </span>
-                  </div>
-
-                  <span className={classes.propSubmissionData}>
+                    by
                     <div className={classes.submittedBy}>
-                      by
                       <EthAddress
                         address={address}
                         hideDavatar={true}
                         className={classes.submittedBy}
                       />
                     </div>
-                    <span className={classes.textSpacer}>{'in the '}</span>
-
-                    {community && (
-                      <Link
-                        to={`/${nameToSlug(community.name)}`}
-                        className={classes.communityProfImgContainer}
-                      >
-                        {community.name.charAt(0).toUpperCase() + community.name.slice(1)}
-                        &nbsp;house
-                      </Link>
-                    )}
-                  </span>
+                  </div>
                 </div>
               )}
 

--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
@@ -34,25 +34,28 @@ const RenderedProposalFields: React.FC<RenderedProposalProps> = props => {
                   <div className={classes.communityAndPropNumber}>
                     <span className={classes.propNumber}>Prop #{proposalId} </span>
                   </div>
-                  &nbsp;
-                  <div className={classes.submittedBy}>
-                    by&nbsp;
-                    <EthAddress
-                      address={address}
-                      hideDavatar={true}
-                      className={classes.submittedBy}
-                    />
-                  </div>
-                  &nbsp;in&nbsp;the&nbsp;
-                  {community && (
-                    <Link
-                      to={`/${nameToSlug(community.name)}`}
-                      className={classes.communityProfImgContainer}
-                    >
-                      {community.name.charAt(0).toUpperCase() + community.name.slice(1)}
-                      &nbsp;house
-                    </Link>
-                  )}
+
+                  <span className={classes.propSubmissionData}>
+                    <div className={classes.submittedBy}>
+                      by
+                      <EthAddress
+                        address={address}
+                        hideDavatar={true}
+                        className={classes.submittedBy}
+                      />
+                    </div>
+                    <span className={classes.textSpacer}>{'in the '}</span>
+
+                    {community && (
+                      <Link
+                        to={`/${nameToSlug(community.name)}`}
+                        className={classes.communityProfImgContainer}
+                      >
+                        {community.name.charAt(0).toUpperCase() + community.name.slice(1)}
+                        &nbsp;house
+                      </Link>
+                    )}
+                  </span>
                 </div>
               )}
 

--- a/packages/prop-house-webapp/src/components/pages/Proposal/Proposal.module.css
+++ b/packages/prop-house-webapp/src/components/pages/Proposal/Proposal.module.css
@@ -11,9 +11,8 @@
 
 .backToAuction:hover {
   color: var(--brand-black);
-  transition-property: color, background-color, border-color,
-    text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-    backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -22,13 +21,5 @@
   .backToAuction svg {
     height: 2rem;
     width: 2rem;
-  }
-  .backToAuction span {
-    display: none;
-  }
-}
-@media (max-width: 576px) {
-  .backToAuction {
-    padding-bottom: 25px;
   }
 }

--- a/packages/prop-house-webapp/src/components/pages/Proposal/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Proposal/index.tsx
@@ -102,10 +102,10 @@ const Proposal = () => {
               address={proposal.address}
               proposalId={proposal.id}
               community={community}
+              roundName={round && round?.title}
               backButton={
                 <div className={classes.backToAuction} onClick={() => handleBackClick()}>
                   <IoArrowBackCircleOutline size={'1.5rem'} />
-                  <span>Back</span>
                 </div>
               }
             />

--- a/packages/prop-house-webapp/src/utils/bgColorForFooter.ts
+++ b/packages/prop-house-webapp/src/utils/bgColorForFooter.ts
@@ -1,10 +1,10 @@
 const bgColorForFooter = (path: string) => {
   const isHousePath = new RegExp('.*/.+').test(path);
   const isProposalPath = new RegExp('.*/.*/.*/.+').test(path);
-  const pages = ['/faq', '/learn', '/create'];
+  const pages = ['/faq', '/create'];
 
-  if (pages.includes(path) || isProposalPath) return 'bgWhite';
-  if (isHousePath || '/') return 'bgGray';
+  if (pages.includes(path)) return 'bgWhite';
+  if (isHousePath || isProposalPath || '/') return 'bgGray';
 
   return 'bgWhite';
 };

--- a/packages/prop-house-webapp/src/utils/bgColorForFooter.ts
+++ b/packages/prop-house-webapp/src/utils/bgColorForFooter.ts
@@ -3,8 +3,8 @@ const bgColorForFooter = (path: string) => {
   const isProposalPath = new RegExp('.*/.*/.*/.+').test(path);
   const pages = ['/faq', '/create'];
 
-  if (pages.includes(path)) return 'bgWhite';
-  if (isHousePath || isProposalPath || '/') return 'bgGray';
+  if (pages.includes(path) || isProposalPath) return 'bgWhite';
+  if (isHousePath || '/') return 'bgGray';
 
   return 'bgWhite';
 };

--- a/packages/prop-house-webapp/src/utils/bgColorForPage.ts
+++ b/packages/prop-house-webapp/src/utils/bgColorForPage.ts
@@ -1,6 +1,5 @@
 const bgColorForPage = (path: string) => {
-  const isProposalPath = new RegExp('.*/.*/.*/.+').test(path);
-  if (path === '/' || isProposalPath) return 'bgGray';
+  if (path === '/') return 'bgGray';
 
   return 'bgWhite';
 };

--- a/packages/prop-house-webapp/src/utils/bgColorForPage.ts
+++ b/packages/prop-house-webapp/src/utils/bgColorForPage.ts
@@ -1,5 +1,6 @@
 const bgColorForPage = (path: string) => {
-  if (path === '/') return 'bgGray';
+  const isProposalPath = new RegExp('.*/.*/.*/.+').test(path);
+  if (path === '/' || isProposalPath) return 'bgGray';
 
   return 'bgWhite';
 };


### PR DESCRIPTION
## New styles for proposal page:
- back button displays the House's Round you're navigating back to next to it
- the proposer address changed to pink
- background color changed to gray
- titles change from gray to black
- replaces #241 

<img width="953" alt="Screen Shot 2022-10-06 at 11 04 57 AM" src="https://user-images.githubusercontent.com/26611339/194348813-74589aa1-5724-4c33-8e14-de811fd44455.png">
