### PR TITLE
render markdown in round card description, but disable links when clicking the card

### DIFF
--- a/packages/prop-house-webapp/src/components/RoundCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundCard/index.tsx
@@ -20,6 +20,7 @@ import { openInNewTab } from '../../utils/openInNewTab';
 import { useAppDispatch } from '../../hooks';
 import { setActiveRound } from '../../state/slices/propHouse';
 import TruncateThousands from '../TruncateThousands';
+import ReactMarkdown from 'react-markdown';
 
 const RoundCard: React.FC<{
   round: StoredAuction;
@@ -55,7 +56,17 @@ const RoundCard: React.FC<{
               <StatusPill status={auctionStatus(round)} />
             </div>
 
-            <div className={classes.truncatedTldr}>{round.description}</div>
+            <ReactMarkdown
+              className={classes.truncatedTldr}
+              children={round.description}
+              disallowedElements={['img', '']}
+              components={{
+                h1: 'p',
+                h2: 'p',
+                h3: 'p',
+                a: 'span',
+              }}
+            ></ReactMarkdown>
           </div>
 
           <div className={classes.roundInfo}>


### PR DESCRIPTION
## Two changes:
1) Render markdown in the Round cards correctly
2) Disable link click on from this screen to prevent the link being clicked in the copy vs the Round card itself

### Before/After
<img width="999" alt="Screen Shot 2022-10-06 at 8 46 15 AM" src="https://user-images.githubusercontent.com/26611339/194316134-5ad17ae7-a11d-42d5-bc0f-6e318d49725e.png">

