### PR TITLE
Fix sticky elements issue

### DIFF
--- a/packages/prop-house-webapp/src/App.css
+++ b/packages/prop-house-webapp/src/App.css
@@ -93,7 +93,6 @@ body {
   flex-direction: column;
   min-height: 100vh;
   max-width: 100vw;
-  overflow-x: hidden;
 }
 .gradientBg {
   background: url('../src/assets/small-pink-pattern@2x.png'),


### PR DESCRIPTION
Sticky elements (house utility bar + round modules) stopped working due to adding the `overflow` property on the `div.wrapper` that wraps the entire app (found in `App.tsx`). removing it to allow child elements that use the css `sticky` property to function correctly.

eg: current deployment in prod does not have sticky house utility bar or round modules. the fix allows for 👇 

<img width="1136" alt="Screen Shot 2022-10-06 at 1 04 14 PM" src="https://user-images.githubusercontent.com/85328329/194374978-e73c1c51-31bb-4f2f-b0fd-188c4ab10406.png">

