### PR TITLE
Parse markdown descriptions to plain text in og cards

### DIFF
--- a/packages/prop-house-webapp/src/components/pages/House/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/House/index.tsx
@@ -2,7 +2,7 @@ import classes from './House.module.css';
 import { useLocation } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../../hooks';
 import HouseHeader from '../../HouseHeader';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useEthers } from '@usedapp/core';
 import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
 import { setActiveCommunity } from '../../../state/slices/propHouse';
@@ -21,6 +21,8 @@ import { sortRoundByStatus } from '../../../utils/sortRoundByStatus';
 import { RoundStatus } from '../../StatusFilters';
 import OpenGraphElements from '../../OpenGraphElements';
 import { cardServiceUrl, CardType } from '../../../utils/cardServiceUrl';
+import ReactMarkdown from 'react-markdown';
+import { markdownComponentToPlainText } from '../../../utils/markdownToPlainText';
 
 const House = () => {
   const location = useLocation();
@@ -116,8 +118,10 @@ const House = () => {
     <>
       {community && (
         <OpenGraphElements
-          title={community.name}
-          description={community.description.toString()}
+          title={`${community.name} Prop House`}
+          description={markdownComponentToPlainText(
+            <ReactMarkdown children={community.description.toString()} />,
+          )}
           imageUrl={cardServiceUrl(CardType.house, community.id).href}
         />
       )}

--- a/packages/prop-house-webapp/src/components/pages/Round/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Round/index.tsx
@@ -19,6 +19,8 @@ import { dispatchSortProposals, SortType } from '../../../utils/sortingProposals
 import { AuctionStatus, auctionStatus } from '../../../utils/auctionStatus';
 import { cardServiceUrl, CardType } from '../../../utils/cardServiceUrl';
 import OpenGraphElements from '../../OpenGraphElements';
+import { markdownComponentToPlainText } from '../../../utils/markdownToPlainText';
+import ReactMarkdown from 'react-markdown';
 
 const Round = () => {
   const location = useLocation();
@@ -79,7 +81,7 @@ const Round = () => {
       {round && (
         <OpenGraphElements
           title={round.title}
-          description={round.description}
+          description={markdownComponentToPlainText(<ReactMarkdown children={round.description} />)}
           imageUrl={cardServiceUrl(CardType.round, round.id).href}
         />
       )}

--- a/packages/prop-house-webapp/src/utils/markdownToPlainText.ts
+++ b/packages/prop-house-webapp/src/utils/markdownToPlainText.ts
@@ -1,0 +1,11 @@
+import ReactDOMServer from 'react-dom/server';
+import { ReactElement } from 'react-markdown/lib/react-markdown';
+
+/**
+ * Takes `ReactMarkdown` component and returns plain text of content
+ */
+export const markdownComponentToPlainText = (reactMarkdownComponent: ReactElement) => {
+  const html = ReactDOMServer.renderToString(reactMarkdownComponent);
+  const stripHtml = html.replace(/<\/?[^>]+(>|$)/g, '');
+  return stripHtml;
+};


### PR DESCRIPTION
Turn markdown being displayed in descriptions to plain text:
<img width="442" alt="Screen Shot 2022-10-06 at 2 47 22 PM" src="https://user-images.githubusercontent.com/85328329/194394209-5fb0aff5-13f0-48ac-84bb-ae17410242af.png">
