### PR TITLE
Hide date on mobile during proposal round on top of voting

### DIFF
--- a/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
@@ -152,11 +152,13 @@
   color: var(--brand-green);
 }
 
-@media (max-width: 575px) {
+@media (max-width: 767px) {
   .hideDate {
     display: none;
   }
+}
 
+@media (max-width: 575px) {
   .address {
     width: max-content;
     white-space: nowrap;

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -31,7 +31,9 @@ const ProposalCard: React.FC<{
 
   const roundIsVotingOrOver = () =>
     auctionStatus === AuctionStatus.AuctionVoting || auctionStatus === AuctionStatus.AuctionEnded;
-  const isVotingPeriod = () => auctionStatus === AuctionStatus.AuctionVoting;
+  const roundIsActive = () =>
+    auctionStatus === AuctionStatus.AuctionAcceptingProps ||
+    auctionStatus === AuctionStatus.AuctionVoting;
 
   return (
     <>
@@ -74,11 +76,11 @@ const ProposalCard: React.FC<{
             <div className={classes.address}>
               <EthAddress address={proposal.address} truncate />
 
-              <span className={clsx(classes.bullet, isVotingPeriod() && classes.hideDate)}>
+              <span className={clsx(classes.bullet, roundIsActive() && classes.hideDate)}>
                 {' • '}
               </span>
               <div
-                className={clsx(classes.date, isVotingPeriod() && classes.hideDate)}
+                className={clsx(classes.date, roundIsActive() && classes.hideDate)}
                 title={detailedTime(proposal.createdDate)}
               >
                 {diffTime(proposal.createdDate)}


### PR DESCRIPTION
We are hiding the date on mobile to prevent overflow cause by a combination of very long ENS names and timestamps. We are already doing this with the cards during Voting status, and now were adding the rule during the Accetpting Props status

### Before & After
<img width="925" alt="Screen Shot 2022-10-06 at 3 43 47 PM" src="https://user-images.githubusercontent.com/26611339/194404505-5b5a29ac-2890-4880-a259-5221903c0f9b.png">
