### PR TITLE
Add UI highlighting to links in the proposal body

### DIFF
--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/RenderedProposalFields.module.css
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/RenderedProposalFields.module.css
@@ -32,6 +32,13 @@
   font-size: 18px;
   color: var(--brand-black);
 }
+.proposalBody a {
+  font-weight: 600;
+  color: var(--brand-pink) !important;
+}
+.proposalBody a:hover {
+  text-decoration: underline !important;
+}
 
 hr {
   background-color: var(--brand-gray-semi-transparent);

--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
@@ -62,35 +62,37 @@ const RenderedProposalFields: React.FC<RenderedProposalProps> = props => {
             </div>
           </div>
 
-          {fields.tldr && (
-            <>
-              <hr></hr>
-              <h2>{t('tldr2')}</h2>
-              <ReactMarkdown className={classes.markdown} children={fields.tldr}></ReactMarkdown>
-            </>
-          )}
+          <span className={classes.proposalBody}>
+            {fields.tldr && (
+              <>
+                <hr></hr>
+                <h2>{t('tldr2')}</h2>
+                <ReactMarkdown className={classes.markdown} children={fields.tldr}></ReactMarkdown>
+              </>
+            )}
 
-          <h2>{t('description')}</h2>
-          {/*
-           * We sanitize HTML coming from rich text editor to prevent xss attacks.
-           *
-           * <Markdown/> component used to render HTML, while supporting Markdown.
-           */}
-          <Markdown>
-            {sanitizeHtml(fields.what, {
-              allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-              allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(['data']),
-              allowedAttributes: {
-                img: ['src', 'alt'],
-                a: ['href', 'target'],
-              },
-              allowedClasses: {
-                code: ['language-*', 'lang-*'],
-                pre: ['language-*', 'lang-*'],
-              },
-              // edge case: handle ampersands in img links encoded from sanitization
-            }).replaceAll('&amp;', '&')}
-          </Markdown>
+            <h2>{t('description')}</h2>
+            {/*
+             * We sanitize HTML coming from rich text editor to prevent xss attacks.
+             *
+             * <Markdown/> component used to render HTML, while supporting Markdown.
+             */}
+            <Markdown>
+              {sanitizeHtml(fields.what, {
+                allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+                allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(['data']),
+                allowedAttributes: {
+                  img: ['src', 'alt'],
+                  a: ['href', 'target'],
+                },
+                allowedClasses: {
+                  code: ['language-*', 'lang-*'],
+                  pre: ['language-*', 'lang-*'],
+                },
+                // edge case: handle ampersands in img links encoded from sanitization
+              }).replaceAll('&amp;', '&')}
+            </Markdown>
+          </span>
         </Col>
       </Row>
     </>


### PR DESCRIPTION
Added a class to target the entire proposal body. Now links (a tags) will be pink and bolded. On hover they'll be underlined like we do in House/Round descriptions. This supports both markdown links and the rich text editor link embeds.

<img width="332" alt="Screen Shot 2022-10-10 at 8 49 37 AM" src="https://user-images.githubusercontent.com/26611339/194870121-19ccdeaf-6453-4d0f-a220-0476b119b69d.png">
