### PR TITLE
During round search, if the filter is set to Active, change it to All Rounds

### DIFF
--- a/packages/prop-house-webapp/src/components/HouseUtilityBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/HouseUtilityBar/index.tsx
@@ -14,7 +14,7 @@ const HouseUtilityBar: React.FC<{
     props;
 
   const handleSearchInputChange = (e: any) => {
-    if (currentRoundStatus !== RoundStatus.Active) setCurrentRoundStatus(RoundStatus.Active);
+    if (currentRoundStatus !== RoundStatus.AllRounds) setCurrentRoundStatus(RoundStatus.AllRounds);
     setInput(e.target.value);
   };
 


### PR DESCRIPTION
If there's either a `Voting` or `Proposing` round, the default filter is `Active`. However, if a user inputs something in the search bar, we want to filter via all rounds available. Therefore, when typing, if the status filter is `Active` let's change it to `All Rounds` to reflect in the UI what's going in the logic.

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/26611339/194902152-dc0916c4-a1f9-49a4-a438-45265bf338e7.gif)
