### PR TITLE
Handle singular round and prop stats

### DIFF
--- a/packages/prop-house-webapp/src/components/HomeStats/index.tsx
+++ b/packages/prop-house-webapp/src/components/HomeStats/index.tsx
@@ -22,11 +22,11 @@ const HomeStats = ({ stats }: HomeStatsProps) => {
     },
     {
       amount: stats.accRounds,
-      text: 'Funding Rounds',
+      text: `Funding ${stats.accRounds === 1 ? 'round' : 'rounds'}`,
     },
     {
       amount: stats.accProps,
-      text: 'Submitted props',
+      text: `Submitted ${stats.accProps === 1 ? 'prop' : 'props'}`,
     },
   ];
 


### PR DESCRIPTION
On the homepage stats section, if there's only 1 round create or 1 prop submitted we should use the singular version of the word.

<img width="482" alt="Screen Shot 2022-10-10 at 4 09 57 PM" src="https://user-images.githubusercontent.com/26611339/194944555-aa2736bf-d322-4e56-9391-1b62e0df7583.png">
