### PR TITLE
Handle HTML in round's description on round card

### DIFF
--- a/packages/prop-house-webapp/src/components/RoundCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundCard/index.tsx
@@ -20,7 +20,8 @@ import { openInNewTab } from '../../utils/openInNewTab';
 import { useAppDispatch } from '../../hooks';
 import { setActiveRound } from '../../state/slices/propHouse';
 import TruncateThousands from '../TruncateThousands';
-import ReactMarkdown from 'react-markdown';
+import Markdown from 'markdown-to-jsx';
+import sanitizeHtml from 'sanitize-html';
 
 const RoundCard: React.FC<{
   round: StoredAuction;
@@ -29,6 +30,16 @@ const RoundCard: React.FC<{
   const { t } = useTranslation();
   let navigate = useNavigate();
   const dispatch = useAppDispatch();
+
+  interface changeTagProps {
+    children: React.ReactNode;
+  }
+
+  // overrides any tag to become a <p> tag
+  const changeTagToParagraph = ({ children }: changeTagProps) => <p>{children}</p>;
+
+  // overrides any tag to become a <span> tag
+  const changeTagToSpan = ({ children }: changeTagProps) => <span>{children}</span>;
 
   return (
     <>
@@ -56,17 +67,21 @@ const RoundCard: React.FC<{
               <StatusPill status={auctionStatus(round)} />
             </div>
 
-            <ReactMarkdown
+            {/* support both markdown & html in round's description.  */}
+            <Markdown
               className={classes.truncatedTldr}
-              children={round.description}
-              disallowedElements={['img', '']}
-              components={{
-                h1: 'p',
-                h2: 'p',
-                h3: 'p',
-                a: 'span',
+              options={{
+                overrides: {
+                  h1: changeTagToParagraph,
+                  h2: changeTagToParagraph,
+                  h3: changeTagToParagraph,
+                  a: changeTagToSpan,
+                  br: changeTagToSpan,
+                },
               }}
-            ></ReactMarkdown>
+            >
+              {sanitizeHtml(round.description)}
+            </Markdown>
           </div>
 
           <div className={classes.roundInfo}>


### PR DESCRIPTION
We were seeing HTML tags in the round's description of the Round card on the House page. Switched from `React Markdown` package to a `Markdown-to-JSX` one that can handle both Markdown and HTML rendering.

We are overriding (meaning changing) the title tags (`h1,  h2, h3`) to regular `<p>` tags so that we're not displaying big titles on our limited-sized card. Also, in this PR we're converating `<a>` tags to `<span>`'s, as mentioned in #251 and we're also overriding `<br>` tags to disallow extra spacing on the card TLDRs. We expect a card's TLDR to read as if it were one paragraph.


### Before (top) & After (bottom)
<img width="796" alt="hackathon" src="https://user-images.githubusercontent.com/26611339/195069691-f899b53d-e823-415a-8c2b-41d2ed8b92ed.png">


