### PR TITLE
Close mobile nav when selection a nav button

### DIFF
--- a/packages/prop-house-webapp/src/components/LocaleSwitcher/index.tsx
+++ b/packages/prop-house-webapp/src/components/LocaleSwitcher/index.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { Dropdown, DropdownButton } from 'react-bootstrap';
 import { BiWorld as World } from 'react-icons/bi';
 import i18n from 'i18next';
+import { Dispatch, SetStateAction } from 'react';
 
 interface Languages {
   en: Language;
@@ -13,7 +14,9 @@ interface Language {
   nativeName: string;
 }
 
-const LocalSwitcher: React.FC<{}> = () => {
+const LocalSwitcher: React.FC<{ setIsNavExpanded: Dispatch<SetStateAction<boolean>> }> = props => {
+  const { setIsNavExpanded } = props;
+
   const lngs: Languages = {
     en: {
       nativeName: 'English',
@@ -29,7 +32,10 @@ const LocalSwitcher: React.FC<{}> = () => {
         <Dropdown.Item
           key={lng}
           as="button"
-          onClick={() => i18n.changeLanguage(lng)}
+          onClick={() => {
+            i18n.changeLanguage(lng);
+            setIsNavExpanded(false);
+          }}
           disabled={i18n.resolvedLanguage === lng}
         >
           {lngs[lng as keyof Languages].nativeName}

--- a/packages/prop-house-webapp/src/components/NavBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/NavBar/index.tsx
@@ -5,13 +5,15 @@ import Web3ModalButton from '../Web3ModalButton.tsx';
 import clsx from 'clsx';
 import LocaleSwitcher from '../LocaleSwitcher';
 import { useTranslation } from 'react-i18next';
+import { useState } from 'react';
 
 const NavBar = () => {
   const { t } = useTranslation();
+  const [isNavExpanded, setIsNavExpanded] = useState(false);
 
   return (
     <Container>
-      <Navbar bg="transparent" expand="lg" className={classes.navbar}>
+      <Navbar bg="transparent" expand="lg" className={classes.navbar} expanded={isNavExpanded}>
         <Link to="/" className={classes.logoGroup}>
           <img className={classes.bulbImg} src="/bulb.png" alt="bulb" />
           <Navbar.Brand>
@@ -22,10 +24,13 @@ const NavBar = () => {
           </Navbar.Brand>
         </Link>
 
-        <Navbar.Toggle aria-controls="basic-navbar-nav" />
+        <Navbar.Toggle
+          aria-controls="basic-navbar-nav"
+          onClick={() => setIsNavExpanded(!isNavExpanded)}
+        />
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className={clsx('ms-auto', classes.navBarCollapse)}>
-            <Nav.Link as="div" className={classes.menuLink}>
+            <Nav.Link as="div" className={classes.menuLink} onClick={() => setIsNavExpanded(false)}>
               <Link to="/faq" className={classes.link}>
                 {t('faq')}
               </Link>
@@ -33,7 +38,7 @@ const NavBar = () => {
             </Nav.Link>
 
             <div className={classes.buttonGroup}>
-              <LocaleSwitcher />
+              <LocaleSwitcher setIsNavExpanded={setIsNavExpanded} />
 
               <Nav.Link as="div">
                 <Web3ModalButton classNames={classes.link} />


### PR DESCRIPTION
When the mobile pop-out menu is open, it would stay open even after a selection was made. Now, if you click a nav item it will close the menu. Also, if you change the selected langauge it will close the menu.

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/26611339/195117505-f8ada187-52c7-4943-b5d5-66c4c8a09427.gif)
