### PR TITLE
Add a space between funding amount and currency type in round utility bar

### DIFF
--- a/packages/prop-house-webapp/src/components/RoundUtilityBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundUtilityBar/index.tsx
@@ -90,8 +90,7 @@ const RoundUtilityBar = ({ auction }: RoundUtilityBarProps) => {
             <div className={classes.itemTitle}>{t('funding')}</div>
 
             <div className={classes.itemData}>
-              <TruncateThousands amount={auction.fundingAmount} />
-              {auction.currencyType}
+              <TruncateThousands amount={auction.fundingAmount} /> {auction.currencyType}{' '}
               <span className={classes.xDivide}>{' × '}</span> {auction.numWinners}
             </div>
           </div>


### PR DESCRIPTION
Add a space funding amount number and the currency type text next to it.

<img width="207" alt="Screen Shot 2022-10-12 at 6 52 45 AM" src="https://user-images.githubusercontent.com/26611339/195324430-29a4778c-6b2a-4c98-b12a-70d5de445a38.png">
