### PR TITLE
Fix NaN issue for calculating "Votes Needed"

### DIFF
--- a/packages/prop-house-webapp/src/components/PropStats/index.tsx
+++ b/packages/prop-house-webapp/src/components/PropStats/index.tsx
@@ -33,7 +33,7 @@ const PropStats: React.FC<{
     return (
       currentlyWinningProps &&
       Number(currentlyWinningProps[currentlyWinningProps.length - 1].voteCount) -
-        Number(prop.score) +
+        Number(prop.voteCount) +
         1
     );
   };


### PR DESCRIPTION
In the `UserPropCard` module there's a component called `PropStats` that gives a builder some info about their standing in a funding round. If they have a proposal that is **not** in the winning group then a calculation is performed (`votesNeededToWin` function) to get the minimum number of votes needed to bump their proposal into the winning batch. 

The issue was that we were returning `NaN` (not a number) for this, and it's because the property used was `prop.score` where it should have been `prop.voteCount`. This has been updated and now works as intended.