### PR TITLE
Hide Davatar on proposal cards

### DIFF
--- a/packages/prop-house-webapp/src/components/EthAddress/index.tsx
+++ b/packages/prop-house-webapp/src/components/EthAddress/index.tsx
@@ -14,7 +14,7 @@ const EthAddress: React.FC<{
   hideDavatar?: boolean;
   imgSize?: number;
 }> = props => {
-  const { address, truncate, hideDavatar, imgSize } = props;
+  const { address, truncate, hideDavatar = true, imgSize } = props;
   const { library: provider } = useEthers();
 
   const etherscanHost = useAppSelector(state => state.configuration.etherscanHost);

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -74,7 +74,7 @@ const ProposalCard: React.FC<{
 
           <div className={classes.timestampAndlinkContainer}>
             <div className={classes.address}>
-              <EthAddress address={proposal.address} truncate />
+              <EthAddress address={proposal.address} truncate hideDavatar={true} />
 
               <span className={clsx(classes.bullet, roundIsActive() && classes.hideDate)}>
                 {' • '}

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -74,7 +74,7 @@ const ProposalCard: React.FC<{
 
           <div className={classes.timestampAndlinkContainer}>
             <div className={classes.address}>
-              <EthAddress address={proposal.address} truncate hideDavatar={true} />
+              <EthAddress address={proposal.address} truncate />
 
               <span className={clsx(classes.bullet, roundIsActive() && classes.hideDate)}>
                 {' • '}


### PR DESCRIPTION
There's a repeating avatar image bug with the `Davatar` npm package, and until we figure out what's causing it we should remove it from the UI.

<img width="352" alt="Screen Shot 2022-10-12 at 1 29 56 PM" src="https://user-images.githubusercontent.com/26611339/195409405-9dbcbfca-8c4b-4c8b-b0ec-225dcfcebbd7.png">
