### PR TITLE
Add decimal support

### DIFF
--- a/packages/prop-house-backend/src/auction/auction.entity.ts
+++ b/packages/prop-house-backend/src/auction/auction.entity.ts
@@ -48,9 +48,9 @@ export class Auction {
   })
   votingEndTime: Date;
 
-  @Column()
-  @Field(type => Float, {
-    description: "The number of currency units paid to each winner"
+  @Column({ type: 'decimal', scale: 2, default: 0.0 })
+  @Field((type) => Float, {
+    description: 'The number of currency units paid to each winner',
   })
   fundingAmount: number;
 

--- a/packages/prop-house-backend/src/db/migrations/1666111078154-UpdateFundingAmountPropertyType.ts
+++ b/packages/prop-house-backend/src/db/migrations/1666111078154-UpdateFundingAmountPropertyType.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class UpdateFundingAmountPropertyType1666111078154 implements MigrationInterface {
+    name = 'UpdateFundingAmountPropertyType1666111078154'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "auction" ALTER COLUMN "fundingAmount" TYPE numeric`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "auction" ALTER COLUMN "fundingAmount" TYPE numeric(2,0)`);
+    }
+
+}

--- a/packages/prop-house-webapp/src/components/RoundCard/RoundCard.module.css
+++ b/packages/prop-house-webapp/src/components/RoundCard/RoundCard.module.css
@@ -277,7 +277,7 @@
 .info {
   color: var(--brand-black);
   font-weight: 700;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 23px;
   letter-spacing: 0.02em;
   height: 23px;

--- a/packages/prop-house-webapp/src/components/RoundCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundCard/index.tsx
@@ -89,7 +89,7 @@ const RoundCard: React.FC<{
               <p className={classes.title}>{t('funding')}</p>
               <p className={classes.info}>
                 <span className="">
-                  <TruncateThousands amount={round.fundingAmount} />
+                  <TruncateThousands amount={round.fundingAmount} decimals={2} />
                   {` ${round.currencyType}`}
                 </span>
                 <span className={classes.xDivide}>{' × '}</span>

--- a/packages/prop-house-webapp/src/components/RoundUtilityBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundUtilityBar/index.tsx
@@ -90,8 +90,9 @@ const RoundUtilityBar = ({ auction }: RoundUtilityBarProps) => {
             <div className={classes.itemTitle}>{t('funding')}</div>
 
             <div className={classes.itemData}>
-              <TruncateThousands amount={auction.fundingAmount} /> {auction.currencyType}{' '}
-              <span className={classes.xDivide}>{' × '}</span> {auction.numWinners}
+              <TruncateThousands amount={auction.fundingAmount} decimals={2} />{' '}
+              {auction.currencyType} <span className={classes.xDivide}>{' × '}</span>{' '}
+              {auction.numWinners}
             </div>
           </div>
 

--- a/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
+++ b/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
@@ -1,6 +1,10 @@
 const TruncateThousands: React.FC<{ amount: number; decimals?: number }> = props => {
   const { amount, decimals } = props;
-  return <>{amount > 1000 ? `${(amount / 1000).toFixed(decimals ? decimals : 1)}K` : amount}</>;
+
+  const addDecimals = (amount: number) =>
+    decimals ? Number(amount).toFixed(decimals) : Number(amount).toFixed(0);
+
+  return <>{addDecimals(amount > 1000 ? amount / 1000 : amount)}</>;
 };
 
 export default TruncateThousands;

--- a/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
+++ b/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
@@ -2,7 +2,11 @@ const TruncateThousands: React.FC<{ amount: number; decimals?: number }> = props
   const { amount, decimals } = props;
 
   const addDecimals = (amount: number) =>
-    decimals ? Number(amount).toFixed(decimals) : Number(amount).toFixed(0);
+    decimals
+      ? amount % 1 != 0
+        ? Number(amount).toFixed(decimals)
+        : amount
+      : Number(amount).toFixed(0);
 
   return <>{addDecimals(amount > 1000 ? amount / 1000 : amount)}</>;
 };

--- a/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
+++ b/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
@@ -3,7 +3,7 @@ const TruncateThousands: React.FC<{ amount: number; decimals?: number }> = props
 
   const addDecimals = (amount: number) =>
     decimals
-      ? amount % 1 != 0
+      ? amount % 1 !== 0
         ? Number(amount).toFixed(decimals)
         : amount
       : Number(amount).toFixed(0);


### PR DESCRIPTION
Various rounds are going to be needing decimal points for their award `fundingAmount`. This PR updates the type for the property as well as adds display when needed within the web app.