### PR TITLE
Add 'K' to truncated homepage stats

### DIFF
--- a/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
+++ b/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
@@ -8,7 +8,12 @@ const TruncateThousands: React.FC<{ amount: number; decimals?: number }> = props
         : amount
       : Number(amount).toFixed(0);
 
-  return <>{addDecimals(amount > 1000 ? amount / 1000 : amount)}</>;
+  return (
+    <>
+      {addDecimals(amount > 1000 ? amount / 1000 : amount)}
+      {amount > 1000 && 'K'}
+    </>
+  );
 };
 
 export default TruncateThousands;

--- a/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
+++ b/packages/prop-house-webapp/src/components/TruncateThousands/index.tsx
@@ -10,8 +10,8 @@ const TruncateThousands: React.FC<{ amount: number; decimals?: number }> = props
 
   return (
     <>
-      {addDecimals(amount > 1000 ? amount / 1000 : amount)}
-      {amount > 1000 && 'K'}
+      {addDecimals(amount >= 1000 ? amount / 1000 : amount)}
+      {amount >= 1000 && 'K'}
     </>
   );
 };


### PR DESCRIPTION
When the stat is 4-digits or more we truncate the number. This commit adds back in the letter 'K' after a truncated number. There's also fix to be inclusive of the number 1000 when checking for truncation.

<img width="539" alt="Screen Shot 2022-10-19 at 12 57 28 PM" src="https://user-images.githubusercontent.com/26611339/196756039-73a99579-d4b8-484d-942d-8969ee59db88.png">
