### PR TITLE
Center modals on screen

### DIFF
--- a/packages/prop-house-webapp/src/css/globals.css
+++ b/packages/prop-house-webapp/src/css/globals.css
@@ -182,3 +182,12 @@ body {
 .infoSymbol svg {
   margin-bottom: 2px;
 }
+
+/* modals */
+.ReactModal__Content {
+  position: absolute !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
+  max-height: max-content !important;
+}

--- a/packages/prop-house-webapp/src/quill.css
+++ b/packages/prop-house-webapp/src/quill.css
@@ -79,8 +79,6 @@ pre {
   width: 100%;
   height: 100%;
   z-index: 10;
-  /* background: rgba(0, 0, 0, 0.6) !important;
-  backdrop-filter: blur(10px); */
   background: rgba(0, 0, 0, 0.12);
   background: rgba(0, 0, 0, 0.18) !important;
   backdrop-filter: blur(10px) !important;


### PR DESCRIPTION
Our modals were slightly below center before, now we've added some CSS to align them horizontally & vertically.

<img width="324" alt="Screen Shot 2022-10-19 at 2 02 58 PM" src="https://user-images.githubusercontent.com/26611339/196769654-fc3af042-bdc8-4de4-bccc-41a2903819de.png">
