### PR TITLE
Support 2 decimal places for round's OpenGraph card funding amount

### DIFF
--- a/packages/prop-house-webapp/src/components/OpenGraphRoundCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/OpenGraphRoundCard/index.tsx
@@ -65,8 +65,7 @@ const OpenGraphRoundCard: React.FC = () => {
             <div className={classes.roundInfo}>
               <span className={classes.title}>Funding:</span>
               <p className={classes.subtitle}>
-                <TruncateThousands amount={round.fundingAmount} />
-                {round.currencyType}
+                <TruncateThousands amount={round.fundingAmount} decimals={2} /> {round.currencyType}
                 <span className={classes.xDivide}>{' × '}</span> {round.numWinners}
               </p>
             </div>


### PR DESCRIPTION
With the addition of rounds with funding amounts with decimals (ie. 0.5, 1.25, etc), the amount was being passed into the `TruncateThousands` component which will round to the nearest whole number (ie. 0.25 becomes 0 and 0.5 becomes 1) unless we pass in a `decimals` prop. Added support for 2 decimal places here and is working as intended. 
 
<img width="1082" alt="Screen Shot 2022-10-20 at 10 07 10 AM" src="https://user-images.githubusercontent.com/26611339/196971393-7a622bdc-cc07-4129-bea9-367a75e8fb32.png">
