### PR TITLE
Increase breakpoint width for hiding section on round card

### DIFF
--- a/packages/prop-house-webapp/src/components/RoundCard/RoundCard.module.css
+++ b/packages/prop-house-webapp/src/components/RoundCard/RoundCard.module.css
@@ -308,6 +308,7 @@
   }
   .roundInfo {
     padding: 1rem;
+    gap: 10px !important;
   }
 }
 @media (max-width: 375px) {

--- a/packages/prop-house-webapp/src/components/RoundCard/RoundCard.module.css
+++ b/packages/prop-house-webapp/src/components/RoundCard/RoundCard.module.css
@@ -306,12 +306,8 @@
   .info {
     font-size: 14px;
   }
-  .roundInfo {
-    padding: 1rem;
-    gap: 10px !important;
-  }
 }
-@media (max-width: 375px) {
+@media (max-width: 450px) {
   .propSection {
     display: none;
   }


### PR DESCRIPTION
With the addition of funding amounts with decimals, the info becomes pretty long so on mobile (450px breakpoint) we hide the `# of proposals` section (previously hidden at 375px) to allow for more room.

<img width="955" alt="Screen Shot 2022-10-20 at 11 09 16 AM" src="https://user-images.githubusercontent.com/26611339/196987424-dbb7481d-dedd-436a-9d5e-6e64ba5d43ec.png">

