### PR TITLE
Sort ended rounds by start time

### DIFF
--- a/packages/prop-house-webapp/src/utils/sortRoundByStatus.ts
+++ b/packages/prop-house-webapp/src/utils/sortRoundByStatus.ts
@@ -12,5 +12,5 @@ export const sortRoundByStatus = (rounds: StoredAuction[]) => [
 
   ...rounds
     .filter(round => auctionStatus(round) === 3)
-    .sort((a, b) => (a.createdDate > b.createdDate ? -1 : 1)),
+    .sort((a, b) => (a.startTime > b.startTime ? -1 : 1)),
 ];


### PR DESCRIPTION
We were originally sorting Ended rounds by the rounds creation date. However, sometimes we create rounds very early in preparation for it but that means rounds that go live after it will be sorted after it, even if said original round actually goes live later. So we fixed this by sorting the Ended rounds by the round's start time.