### PR TITLE
Null check in House sharing card

### DIFF
--- a/packages/prop-house-webapp/src/components/OpenGraphHouseCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/OpenGraphHouseCard/index.tsx
@@ -51,16 +51,16 @@ const OpenGraphHouseCard: React.FC = () => {
               <span className={classes.roundInfoContainer}>
                 <div className={classes.roundInfo}>
                   <span className={classes.title}>Rounds</span>
-                  <p className={classes.subtitle}>{community.numAuctions}</p>
+                  <p className={classes.subtitle}>{community.numAuctions ?? 0}</p>
                 </div>
 
                 <div className={classes.roundInfo}>
                   <span className={classes.title}>Proposals</span>
-                  <p className={classes.subtitle}>{community.numProposals}</p>
+                  <p className={classes.subtitle}>{community.numProposals ?? 0}</p>
                 </div>
                 <div className={classes.roundInfo}>
                   <span className={classes.title}>Funded</span>
-                  <p className={classes.subtitle}>Ξ {community.ethFunded}</p>
+                  <p className={classes.subtitle}>Ξ {community.ethFunded ?? 0}</p>
                 </div>
               </span>
             </span>


### PR DESCRIPTION
When a new house is created there have been no rounds created, proposals submitted, or currency distributed. Since these values are `null`, in the social sharing card we were seeing "nothing" where we _should_ have been display `0` to the user. This PR checks for null values & displays a `0` if `null` is returned.

### Before (bottom) & After (top)
![Screenshot 2022-11-08 at 12 06 57 PM](https://user-images.githubusercontent.com/26611339/200629760-87583bad-b126-439e-a9df-9d58bdcd641b.png)
