### PR TITLE
Add 0 if there's no proposals or rounds

### DIFF
--- a/packages/prop-house-webapp/src/components/HouseHeader/index.tsx
+++ b/packages/prop-house-webapp/src/components/HouseHeader/index.tsx
@@ -62,14 +62,16 @@ const HouseHeader: React.FC<{
           </div>
 
           <div className={classes.propHouseDataRow}>
-            <div className={classes.itemData}>{community.numAuctions}</div>
+            <div className={classes.itemData}>{community.numAuctions ?? 0}</div>
             <div className={classes.itemTitle}>
-              {community?.numAuctions === 1 ? 'Round' : 'Rounds'}
+              {community.numAuctions === 1 ? 'Round' : 'Rounds'}
             </div>
             <span className={classes.bullet}>{' • '}</span>
 
-            <div className={classes.itemData}>{community.numProposals}</div>
-            <div className={classes.itemTitle}>{'Proposals'}</div>
+            <div className={classes.itemData}>{community.numProposals ?? 0}</div>
+            <div className={classes.itemTitle}>
+              {community.numProposals === 1 ? 'Proposal' : 'Proposals'}
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
UI bug that displays nothing if there's either zero proposals or zero round on a House. We should show the number 0 instead of nothing.

<img width="619" alt="Screenshot 2022-11-14 at 3 31 31 PM" src="https://user-images.githubusercontent.com/26611339/201759866-13dcf755-b3d1-4f0c-8506-c0663b4df09d.png">
