### PR TITLE
Swap currency type and amount order & support multiple currency types

### DIFF
--- a/packages/prop-house-webapp/src/components/CommunityCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/CommunityCard/index.tsx
@@ -3,6 +3,7 @@ import { Community } from '@nouns/prop-house-wrapper/dist/builders';
 import CommunityProfImg from '../CommunityProfImg';
 import { useTranslation } from 'react-i18next';
 import TruncateThousands from '../TruncateThousands';
+import getHouseCurrency from '../../utils/getHouseCurrency';
 
 const CommunityCard: React.FC<{
   community: Community;
@@ -20,10 +21,8 @@ const CommunityCard: React.FC<{
           <div className={classes.infoWithSymbol}>
             <div className={classes.infoText}>
               <span className={classes.infoAmount}>
-                {community.contractAddress === '0x7Bd29408f11D2bFC23c34f18275bBf23bB716Bc7'
-                  ? 'APE'
-                  : 'Ξ'}{' '}
-                <TruncateThousands amount={community.ethFunded} />
+                <TruncateThousands amount={community.ethFunded} />{' '}
+                {getHouseCurrency(community.contractAddress)}
               </span>{' '}
               <span className={classes.infoCopy}>funded</span>
             </div>

--- a/packages/prop-house-webapp/src/utils/getHouseCurrency.ts
+++ b/packages/prop-house-webapp/src/utils/getHouseCurrency.ts
@@ -1,0 +1,16 @@
+/**
+ * Not all houses use ETH as their currency. This function returns the currency of the house.
+ * @param contractAddress Address of house
+ * @returns Currency type of house
+ */
+const getHouseCurrency = (contractAddress: string) => {
+  if (contractAddress === '0x7Bd29408f11D2bFC23c34f18275bBf23bB716Bc7') {
+    return 'APE';
+  } else if (contractAddress === '0x2381b67c6f1cb732fdf8b3b29d3260ec6f7420bc') {
+    return 'UMA';
+  } else {
+    return 'Ξ';
+  }
+};
+
+export default getHouseCurrency;


### PR DESCRIPTION
We had ETH as the only currency type and displayed the `Ξ` symbol for every house on the homepage. However now that we have multiple house with alternative currency types we need to support that in the UI. Also we have swapped the order of currency type and amount. So it will now say "4 Ξ" vs. "Ξ 4".