### PR TITLE
Support various currency types for House's social sharing card

### DIFF
--- a/packages/prop-house-webapp/src/components/OpenGraphHouseCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/OpenGraphHouseCard/index.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 import { useAppSelector } from '../../hooks';
 import CommunityProfImg from '../CommunityProfImg';
 import { Community } from '@nouns/prop-house-wrapper/dist/builders';
+import getHouseCurrency from '../../utils/getHouseCurrency';
 
 const OpenGraphHouseCard: React.FC = () => {
   const params = useParams();
@@ -60,7 +61,9 @@ const OpenGraphHouseCard: React.FC = () => {
                 </div>
                 <div className={classes.roundInfo}>
                   <span className={classes.title}>Funded</span>
-                  <p className={classes.subtitle}>Ξ {community.ethFunded ?? 0}</p>
+                  <p className={classes.subtitle}>
+                    {community.ethFunded ?? 0} {getHouseCurrency(community.contractAddress)}
+                  </p>
                 </div>
               </span>
             </span>

--- a/packages/prop-house-webapp/src/components/OpenGraphHouseCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/OpenGraphHouseCard/index.tsx
@@ -7,6 +7,7 @@ import { useAppSelector } from '../../hooks';
 import CommunityProfImg from '../CommunityProfImg';
 import { Community } from '@nouns/prop-house-wrapper/dist/builders';
 import getHouseCurrency from '../../utils/getHouseCurrency';
+import TruncateThousands from '../TruncateThousands';
 
 const OpenGraphHouseCard: React.FC = () => {
   const params = useParams();
@@ -62,7 +63,8 @@ const OpenGraphHouseCard: React.FC = () => {
                 <div className={classes.roundInfo}>
                   <span className={classes.title}>Funded</span>
                   <p className={classes.subtitle}>
-                    {community.ethFunded ?? 0} {getHouseCurrency(community.contractAddress)}
+                    <TruncateThousands amount={community.ethFunded ?? 0} />{' '}
+                    {getHouseCurrency(community.contractAddress)}
                   </p>
                 </div>
               </span>


### PR DESCRIPTION
1) use the new `getHouseCurrency` util func to return correct currency type for social sharing cards (ie. APE/ UMA/ETH)
2) swap order of currency type & currency amount