### PR TITLE
Remove colons from url slugs

### DIFF
--- a/packages/prop-house-webapp/package.json
+++ b/packages/prop-house-webapp/package.json
@@ -52,6 +52,7 @@
     "react-scripts": "4.0.3",
     "remark-breaks": "^3.0.2",
     "sanitize-html": "^2.7.0",
+    "slugify": "^1.6.5",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1",
     "web3modal": "^1.9.5",

--- a/packages/prop-house-webapp/src/utils/communitySlugs.ts
+++ b/packages/prop-house-webapp/src/utils/communitySlugs.ts
@@ -1,4 +1,5 @@
-export const nameToSlug = (name: string) =>
-  name.replaceAll(':', '').replaceAll(' ', '-').toLowerCase();
+import slugify from 'slugify';
+
+export const nameToSlug = (name: string) => slugify(name, { lower: true, strict: true });
 
 export const slugToName = (slug: string) => slug.replaceAll('-', ' ');

--- a/packages/prop-house-webapp/src/utils/communitySlugs.ts
+++ b/packages/prop-house-webapp/src/utils/communitySlugs.ts
@@ -1,4 +1,4 @@
 export const nameToSlug = (name: string) =>
-  name.replaceAll(' ', '-').toLowerCase();
+  name.replaceAll(':', '').replaceAll(' ', '-').toLowerCase();
 
 export const slugToName = (slug: string) => slug.replaceAll('-', ' ');

--- a/yarn.lock
+++ b/yarn.lock
@@ -16753,6 +16753,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+slugify@^1.6.5:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.5.tgz#c8f5c072bf2135b80703589b39a3d41451fbe8c8"
+  integrity sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"


### PR DESCRIPTION
When rounds have colons (ie. `Open Round: 12`), building url slugs get messed up when you're opening them in a new tab. This PR removes them so the slugs are `prop.house/nouns/open-round-12` vs`prop.house/nouns/open-round:-12`