### PR TITLE
Filter out non-ETH houses from homepage 'ETH Funded' stat

### DIFF
--- a/packages/prop-house-webapp/src/components/pages/Home/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Home/index.tsx
@@ -44,7 +44,11 @@ const Home = () => {
       const communities = await client.current.getCommunities();
 
       setCommunities(communities.sort((a, b) => (a.ethFunded < b.ethFunded ? 1 : -1)));
-      const accEthFunded = communities.reduce((prev, current) => prev + current.ethFunded, 0);
+
+      const accEthFunded = communities
+        .filter((c: any) => c.contractAddress !== '0x7Bd29408f11D2bFC23c34f18275bBf23bB716Bc7')
+        .filter((c: any) => c.contractAddress !== '0x2381b67c6f1cb732fdf8b3b29d3260ec6f7420bc')
+        .reduce((prev, current) => prev + current.ethFunded, 0);
       const accRounds = communities.reduce((prev, current) => prev + current.numAuctions, 0);
       const accProps = communities.reduce((prev, current) => prev + current.numProposals, 0);
       setStats({


### PR DESCRIPTION
The homepage statistic for "ETH Funded" was including non-ETH currencies as well, conflating the number. By filtering out UMA & Meebits houses from this number we get a better picture of actual ETH deployed. This is a temporary fix while we wait for the `community` object to be updated with more `currency` values.

<img width="491" alt="Screenshot 2022-11-16 at 3 55 07 PM" src="https://user-images.githubusercontent.com/26611339/202292287-43f7b1d9-afda-4bcf-b2dd-6bbf1cdc2010.png">
