### PR TITLE
Add white background to House image

### DIFF
--- a/packages/prop-house-webapp/src/components/CommunityProfImg/CommunityProfImg.module.css
+++ b/packages/prop-house-webapp/src/components/CommunityProfImg/CommunityProfImg.module.css
@@ -5,6 +5,7 @@
   box-shadow: 0 4px 6px 2px rgba(0, 0, 0, 0.05) !important;
   transition: all 0.15s ease-in-out;
   cursor: default;
+  background: white;
 }
 
 .hoverImg:hover {


### PR DESCRIPTION
To better support PNGs, i've added a white background to the image to prevent seeing through to the background.

### Before
<img width="380" alt="Screenshot 2022-11-16 at 4 08 42 PM" src="https://user-images.githubusercontent.com/26611339/202294665-35fa3680-22c4-4c09-9a73-4bf987a38abe.png">

### After
<img width="630" alt="Screenshot 2022-11-16 at 4 09 10 PM" src="https://user-images.githubusercontent.com/26611339/202294748-e6d69c99-4fac-4463-ae37-9b9a4ce52b7d.png">
