### PR TITLE
Revert slugify

### DIFF
--- a/packages/prop-house-webapp/src/utils/communitySlugs.ts
+++ b/packages/prop-house-webapp/src/utils/communitySlugs.ts
@@ -1,5 +1,3 @@
-import slugify from 'slugify';
-
-export const nameToSlug = (name: string) => slugify(name, { lower: true, strict: true });
+export const nameToSlug = (name: string) => name.replaceAll(' ', '-').toLowerCase();
 
 export const slugToName = (slug: string) => slug.replaceAll('-', ' ');


### PR DESCRIPTION
Removing colons from slugs doesn't work when the round is the entry point (it breaks in the`getAuctionWithNameForCommunity` call). Reverting until another solution is found.