### PR TITLE
Hot fix: Use default provider to fetch votes

### DIFF
--- a/packages/prop-house-webapp/src/components/RoundContent/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundContent/index.tsx
@@ -32,6 +32,7 @@ import getWinningIds from '../../utils/getWinningIds';
 import isWinner from '../../utils/isWinner';
 import { useTranslation } from 'react-i18next';
 import RoundModules from '../RoundModules';
+import { InfuraProvider } from '@ethersproject/providers';
 
 const RoundContent: React.FC<{
   auction: StoredAuction;
@@ -92,10 +93,11 @@ const RoundContent: React.FC<{
 
     const fetchVotes = async () => {
       try {
+        const provider = new InfuraProvider(1, process.env.REACT_APP_INFURA_PROJECT_ID);
         const votes = await getNumVotes(
           account,
           community.contractAddress,
-          library,
+          provider,
           auction.balanceBlockTag,
         );
         dispatch(setVotingPower(votes));


### PR DESCRIPTION
`useDapp` is causing issues where metamask throws error when trying to fetch votes. This hot fix uses our default provider for fetching votes.