### PR TITLE
Type corercion for number of rounds

### DIFF
--- a/packages/prop-house-webapp/src/components/HouseHeader/index.tsx
+++ b/packages/prop-house-webapp/src/components/HouseHeader/index.tsx
@@ -89,7 +89,7 @@ const HouseHeader: React.FC<{
           <div className={classes.propHouseDataRow}>
             <div className={classes.itemData}>{community.numAuctions ?? 0}</div>
             <div className={classes.itemTitle}>
-              {community?.numAuctions === 1 ? 'Round' : 'Rounds'}
+              {Number(community?.numAuctions) === 1 ? 'Round' : 'Rounds'}
             </div>
             <span className={classes.bullet}>{' • '}</span>
 


### PR DESCRIPTION
When there's only one round we were still seeing the use of the plural "Rounds" due to a conditional looking for a Number but getting back String.
<img width="459" alt="Screenshot 2022-12-01 at 10 16 22 AM" src="https://user-images.githubusercontent.com/26611339/205089682-0a6ec9f1-cf79-4586-b79e-127375af6030.png">
