### PR TITLE
Handle proposer info overflow with ellipsis

### DIFF
--- a/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
@@ -164,8 +164,13 @@
     width: max-content;
     white-space: nowrap;
     text-overflow: ellipsis;
-    display: block;
+    display: flex;
     overflow: hidden;
+  }
+  .date {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
### Before
<img width="675" alt="Screenshot 2022-12-01 at 10 30 49 AM" src="https://user-images.githubusercontent.com/26611339/205093228-9dcc08dd-1dcf-4b2a-b422-c1c32273f805.png">

### After
<img width="314" alt="Screenshot 2022-12-01 at 10 29 14 AM" src="https://user-images.githubusercontent.com/26611339/205093283-239cb36b-3674-4353-aeef-013333f416c6.png">
