### PR TITLE
Fix overflow columns on round utility bar

### DIFF
--- a/packages/prop-house-webapp/src/components/RoundUtilityBar/RoundUtilityBar.module.css
+++ b/packages/prop-house-webapp/src/components/RoundUtilityBar/RoundUtilityBar.module.css
@@ -141,4 +141,13 @@
   .propHouseDataRow {
     justify-content: inherit;
   }
+  .item:nth-child(3) {
+    display: block;
+  }
+  .item:nth-child(2) {
+    border-right: 1px solid var(--border-light) !important;
+  }
+  .item:nth-child(3) {
+    border-right: none !important;
+  }
 }

--- a/packages/prop-house-webapp/src/components/RoundUtilityBar/RoundUtilityBar.module.css
+++ b/packages/prop-house-webapp/src/components/RoundUtilityBar/RoundUtilityBar.module.css
@@ -37,6 +37,13 @@
   .sortToggles {
     display: none;
   }
+  .item:nth-child(3),
+  .item:nth-child(4) {
+    display: none;
+  }
+  .item:nth-child(2) {
+    border-right: none !important;
+  }
 }
 
 .propHouseDataRow {
@@ -116,9 +123,6 @@
 }
 
 @media (max-width: 700px) {
-  .proposalCountItem {
-    display: none;
-  }
   .item:first-child {
     padding-right: 6px !important;
   }
@@ -126,7 +130,7 @@
     justify-content: flex-end;
   }
 }
-@media (max-width: 500px) {
+@media (max-width: 550px) {
   .roundUtilityBar {
     flex-direction: column-reverse;
     height: auto;

--- a/packages/prop-house-webapp/src/components/RoundUtilityBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundUtilityBar/index.tsx
@@ -98,7 +98,7 @@ const RoundUtilityBar = ({ auction }: RoundUtilityBarProps) => {
             </div>
           </div>
 
-          <div className={clsx(classes.item, classes.proposalCountItem)}>
+          <div className={classes.item}>
             <div className={classes.itemTitle}>
               {proposals && proposals.length === 1 ? 'Proposal' : 'Proposals'}
             </div>


### PR DESCRIPTION
Now that we have a new item (`Snapshot`), it takes up more real estate and the breakpoints were off, causing overflow UI on medium to small screens. This PR updates the breakpoints to show/hide content in the Round utility bar. 

![Screenshot 2022-12-02 at 11 05 21 AM](https://user-images.githubusercontent.com/26611339/205334909-350295b0-d170-4cb7-a509-3aab49ac7817.png)
