### PR TITLE
Round page search bar to filter proposals

### DIFF
--- a/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
@@ -5,7 +5,6 @@
   transition: background-color var(--card-transition), filter var(--card-transition);
   filter: drop-shadow(var(--shadow-low));
   border: 1px solid var(--border-med);
-  margin: 1.5rem 0;
 }
 
 .proposalCard:hover {

--- a/packages/prop-house-webapp/src/components/RoundModules/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundModules/index.tsx
@@ -21,13 +21,16 @@ import RoundOverModule from '../RoundOverModule';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { isSameAddress } from '../../utils/isSameAddress';
 import { voteWeightForAllottedVotes } from '../../utils/voteWeightForAllottedVotes';
+import SearchBar from '../SeachBar';
 
 const RoundModules: React.FC<{
   auction: StoredAuction;
   community: Community;
   setShowVotingModal: Dispatch<SetStateAction<boolean>>;
+  input: string;
+  handleProposalSearch: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }> = props => {
-  const { auction, community, setShowVotingModal } = props;
+  const { auction, community, setShowVotingModal, input, handleProposalSearch } = props;
 
   const { account } = useEthers();
   const connect = useWeb3Modal();
@@ -76,6 +79,15 @@ const RoundModules: React.FC<{
           winningIds={winningIds && winningIds}
         />
       )}
+
+      <div className="proposalSearchBarDesktop">
+        <SearchBar
+          input={input}
+          handleSeachInputChange={handleProposalSearch}
+          placeholder="Search for proposals"
+          disabled={proposals && proposals.length === 0}
+        />
+      </div>
 
       <Card
         bgColor={CardBgColor.White}

--- a/packages/prop-house-webapp/src/components/SeachBar/SearchBar.module.css
+++ b/packages/prop-house-webapp/src/components/SeachBar/SearchBar.module.css
@@ -60,3 +60,7 @@
     padding-right: 0px;
   }
 }
+.searchBar input:disabled {
+  pointer-events: none !important;
+  border: 1px solid var(--border-light) !important;
+}

--- a/packages/prop-house-webapp/src/components/SeachBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/SeachBar/index.tsx
@@ -5,9 +5,10 @@ interface SearchBarProps {
   input: string;
   handleSeachInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder: string;
+  disabled?: boolean;
 }
 
-const SearchBar = ({ input, handleSeachInputChange, placeholder }: SearchBarProps) => {
+const SearchBar = ({ input, handleSeachInputChange, placeholder, disabled }: SearchBarProps) => {
   return (
     <div className={classes.searchBar}>
       <span className={classes.searchIcon}>
@@ -19,6 +20,7 @@ const SearchBar = ({ input, handleSeachInputChange, placeholder }: SearchBarProp
         value={input}
         onChange={e => handleSeachInputChange(e)}
         placeholder={placeholder}
+        disabled={disabled}
       />
     </div>
   );

--- a/packages/prop-house-webapp/src/css/globals.css
+++ b/packages/prop-house-webapp/src/css/globals.css
@@ -191,3 +191,32 @@ body {
   transform: translate(-50%, -50%) !important;
   max-height: max-content !important;
 }
+
+.proposalSearchBarDesktop input,
+.proposalSearchBarMobile input {
+  margin: 0.75rem 0rem 1.25rem 0rem !important;
+  border-radius: 14px !important;
+  box-shadow: var(--shadow-low) !important;
+  width: 100% !important;
+  min-width: 100% !important;
+}
+@media (min-width: 1201px) {
+  .proposalSearchBarMobile {
+    display: none;
+  }
+}
+@media (max-width: 1200px) {
+  .proposalSearchBarMobile {
+    margin-bottom: 0.5rem;
+    margin-top: -15px;
+  }
+  .proposalSearchBarDesktop {
+    display: none;
+  }
+}
+@media (max-width: 767px) {
+  .proposalSearchBarMobile {
+    margin-bottom: 1.5rem;
+    margin-top: -20px;
+  }
+}


### PR DESCRIPTION
Add a search bar to the Round page to filter through proposals. User can search by proposal title, tldr, or body. The search bar is disabled when there are no proposals.

## Searching state
<img width="1034" alt="Screenshot 2022-12-02 at 4 36 20 PM" src="https://user-images.githubusercontent.com/26611339/205393044-fcfc6408-ffa1-4226-9fba-a558d3a7d789.png">

## No results found state
<img width="997" alt="Screenshot 2022-12-02 at 4 36 56 PM" src="https://user-images.githubusercontent.com/26611339/205393303-6b8d93e4-27a0-42d5-80af-91c3d55cd8c3.png">

## Disabled state (no proposals)
<img width="1057" alt="Screenshot 2022-12-02 at 4 37 06 PM" src="https://user-images.githubusercontent.com/26611339/205393412-87a2fe49-3f17-42b7-b6b9-fa9747828aa9.png">
