### PR TITLE
Add ability to PATCH and DELETE Proposals

### DIFF
--- a/packages/prop-house-backend/src/db/migrations/1670995397176-ProposalSoftDelete.ts
+++ b/packages/prop-house-backend/src/db/migrations/1670995397176-ProposalSoftDelete.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ProposalSoftDelete1670995397176 implements MigrationInterface {
+  name = 'ProposalSoftDelete1670995397176';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "proposal" ADD "deletedAt" TIMESTAMP`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "proposal" DROP COLUMN "deletedAt"`);
+  }
+}

--- a/packages/prop-house-backend/src/proposal/proposal.entity.ts
+++ b/packages/prop-house-backend/src/proposal/proposal.entity.ts
@@ -13,6 +13,7 @@ import {
   BeforeUpdate,
   BeforeInsert,
   RelationId,
+  DeleteDateColumn,
 } from 'typeorm';
 
 @Entity()
@@ -81,4 +82,7 @@ export class Proposal extends SignedEntity {
   setUpdatedDate() {
     this.lastUpdatedDate = new Date();
   }
+
+  @DeleteDateColumn()
+  deletedAt: Date;
 }

--- a/packages/prop-house-backend/src/proposal/proposal.types.ts
+++ b/packages/prop-house-backend/src/proposal/proposal.types.ts
@@ -29,6 +29,16 @@ export class CreateProposalDto extends SignedEntity {
   parentAuctionId: number;
 }
 
+export class UpdateProposalDto extends CreateProposalDto {
+  @IsNumber()
+  id: number;
+}
+
+export class DeleteProposalDto extends SignedEntity {
+  @IsNumber()
+  id: number;
+}
+
 export class GetProposalsDto {
   @IsOptional()
   @IsInt()

--- a/packages/prop-house-backend/src/utils/date.ts
+++ b/packages/prop-house-backend/src/utils/date.ts
@@ -1,1 +1,6 @@
+import { Auction } from 'src/auction/auction.entity';
+
 export const ParseDate = (str) => new Date(str);
+
+export const canSubmitProposals = (auction: Auction): boolean =>
+  new Date() > auction.startTime && new Date() <= auction.proposalEndTime;

--- a/packages/prop-house-wrapper/src/builders.ts
+++ b/packages/prop-house-wrapper/src/builders.ts
@@ -149,6 +149,25 @@ export class Proposal extends Signable {
   }
 }
 
+export class UpdatedProposal extends Proposal {
+  constructor(
+    public readonly id: number,
+    public readonly title: string,
+    public readonly what: string,
+    public readonly tldr: string,
+    public readonly auctionId: number,
+  ) {
+    super(title, what, tldr, auctionId);
+  }
+
+  toPayload() {
+    return {
+      id: this.id,
+      ...super.toPayload(),
+    };
+  }
+}
+
 export interface StoredProposal extends Proposal {
   id: number;
   address: string;
@@ -158,6 +177,18 @@ export interface StoredProposal extends Proposal {
 
 export interface StoredProposalWithVotes extends StoredProposal {
   votes: StoredVote[];
+}
+
+export class DeleteProposal extends Signable {
+  constructor(public readonly id: number) {
+    super();
+  }
+
+  toPayload() {
+    return {
+      id: this.id,
+    };
+  }
 }
 
 export enum Direction {

--- a/packages/prop-house-wrapper/src/index.ts
+++ b/packages/prop-house-wrapper/src/index.ts
@@ -10,6 +10,8 @@ import {
   Vote,
   Community,
   CommunityWithAuctions,
+  UpdatedProposal,
+  DeleteProposal,
 } from './builders';
 import FormData from 'form-data';
 import fs from 'fs';
@@ -112,6 +114,26 @@ export class PropHouseWrapper {
         ProposalMessageTypes,
       );
       return (await axios.post(`${this.host}/proposals`, signedPayload)).data;
+    } catch (e: any) {
+      throw e.response.data.message;
+    }
+  }
+
+  async updateProposal(updatedProposal: UpdatedProposal) {
+    if (!this.signer) return;
+    try {
+      const signedPayload = await updatedProposal.signedPayload(this.signer);
+      return (await axios.patch(`${this.host}/proposals`, signedPayload)).data;
+    } catch (e: any) {
+      throw e.response.data.message;
+    }
+  }
+
+  async deleteProposal(deleteProposal: DeleteProposal) {
+    if (!this.signer) return;
+    try {
+      const signedPayload = await deleteProposal.signedPayload(this.signer);
+      return (await axios.delete(`${this.host}/proposals`, signedPayload)).data;
     } catch (e: any) {
       throw e.response.data.message;
     }

--- a/packages/prop-house-wrapper/src/index.ts
+++ b/packages/prop-house-wrapper/src/index.ts
@@ -119,20 +119,20 @@ export class PropHouseWrapper {
     }
   }
 
-  async updateProposal(updatedProposal: UpdatedProposal) {
+  async updateProposal(updatedProposal: UpdatedProposal, isContract = false) {
     if (!this.signer) return;
     try {
-      const signedPayload = await updatedProposal.signedPayload(this.signer);
+      const signedPayload = await updatedProposal.signedPayload(this.signer, isContract);
       return (await axios.patch(`${this.host}/proposals`, signedPayload)).data;
     } catch (e: any) {
       throw e.response.data.message;
     }
   }
 
-  async deleteProposal(deleteProposal: DeleteProposal) {
+  async deleteProposal(deleteProposal: DeleteProposal, isContract = false) {
     if (!this.signer) return;
     try {
-      const signedPayload = await deleteProposal.signedPayload(this.signer);
+      const signedPayload = await deleteProposal.signedPayload(this.signer, isContract);
       return (await axios.delete(`${this.host}/proposals`, signedPayload)).data;
     } catch (e: any) {
       throw e.response.data.message;


### PR DESCRIPTION
This PR adds support for PATCH and DELETE verbs to the `/proposals` endpoint in order to support users being able to delete or update their proposals.

## `PATCH /proposals`
This endpoint requires a body that matches [UpateProposalDto](https://github.com/Prop-House/prop-house-monorepo/blob/carrot-prop-patch/packages/prop-house-backend/src/proposal/proposal.types.ts#L32-L35) and is signed by the author.

## `DELETE /proposals`
This endpoint requires a body that matches [DeleteProposalDto](https://github.com/Prop-House/prop-house-monorepo/blob/carrot-prop-patch/packages/prop-house-backend/src/proposal/proposal.types.ts#L37-L40) and is signed by the proposal author. This differs from a more normal `DELETE /proposals/:id` path because the proposal ID must be part of the payload that is being signed and having the ID in two locations seemed like a duplicate.