### PR TITLE
Winning Proposals UI

### DIFF
--- a/packages/prop-house-webapp/src/components/Button/Button.module.css
+++ b/packages/prop-house-webapp/src/components/Button/Button.module.css
@@ -1,6 +1,7 @@
 .btn {
   border-radius: 10px;
   padding: 0.575rem 0.65rem 0.525rem;
+  padding: 6px 12px !important;
   white-space: normal;
   text-align: center;
   font-size: 16px !important;

--- a/packages/prop-house-webapp/src/components/PropCardsAndModules/index.tsx
+++ b/packages/prop-house-webapp/src/components/PropCardsAndModules/index.tsx
@@ -85,7 +85,7 @@ const PropCardsAndModules: React.FC<{
                     proposal={proposal}
                     auctionStatus={auctionStatus(auction)}
                     cardStatus={cardStatus(votingPower > 0, auction)}
-                    winner={winningIds && isWinner(winningIds, proposal.id)}
+                    isWinner={winningIds && isWinner(winningIds, proposal.id)}
                   />
                 </Col>
               );

--- a/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
@@ -44,6 +44,12 @@
   color: var(--brand-black-transparent);
   display: inline;
 }
+.crownNoun {
+  display: flex;
+}
+.crownNoun img {
+  height: 14px;
+}
 
 .date {
   font-weight: 500;
@@ -128,8 +134,7 @@
 .titleContainer {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 15px;
+  gap: 5px;
 }
 
 .address {

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -55,7 +55,7 @@ const ProposalCard: React.FC<{
         <Card
           bgColor={CardBgColor.White}
           borderRadius={CardBorderRadius.thirty}
-          classNames={clsx(classes.proposalCard, isWinner && classes.winner)}
+          classNames={clsx(classes.proposalCard, isWinner && auctionStatus === AuctionStatus.AuctionEnded && classes.winner)}
         >
           <div className={classes.textContainter}>
             <div className={classes.titleContainer}>

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -22,9 +22,9 @@ const ProposalCard: React.FC<{
   proposal: StoredProposalWithVotes;
   auctionStatus: AuctionStatus;
   cardStatus: ProposalCardStatus;
-  winner?: boolean;
+  isWinner?: boolean;
 }> = props => {
-  const { proposal, auctionStatus, cardStatus, winner } = props;
+  const { proposal, auctionStatus, cardStatus, isWinner } = props;
 
   let navigate = useNavigate();
 
@@ -55,10 +55,13 @@ const ProposalCard: React.FC<{
         <Card
           bgColor={CardBgColor.White}
           borderRadius={CardBorderRadius.thirty}
-          classNames={clsx(classes.proposalCard, winner && classes.winner)}
+          classNames={clsx(classes.proposalCard, isWinner && classes.winner)}
         >
           <div className={classes.textContainter}>
             <div className={classes.titleContainer}>
+              {isWinner && <div className={classes.crownNoun}>
+                <img src="/heads/crown.png" alt="crown" />
+              </div>}
               <div className={classes.authorContainer}>{proposal.title}</div>
             </div>
 

--- a/packages/prop-house-webapp/src/components/ProposalHeaderAndBody/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalHeaderAndBody/index.tsx
@@ -89,6 +89,7 @@ const ProposalHeaderAndBody: React.FC<ProposalHeaderAndBodyProps> = (
                   isFirstProp={isFirstProp}
                   isLastProp={isLastProp && isLastProp}
                   showVoteAllotmentModal={showVoteAllotmentModal}
+                  proposal={currentProposal}
                 />
 
                 <Divider />

--- a/packages/prop-house-webapp/src/components/ProposalModal/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalModal/index.tsx
@@ -78,6 +78,7 @@ const ProposalModal = () => {
   const isVotingWindow = round && auctionStatus(round) === AuctionStatus.AuctionVoting;
   const winningIds = round && getWinningIds(proposals, round);
 
+
   const handleClosePropModal = () => {
     if (!community || !round) return;
     setShowProposalModal(false);

--- a/packages/prop-house-webapp/src/components/ProposalModalFooter/ProposalModalFooter.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalFooter/ProposalModalFooter.module.css
@@ -11,6 +11,11 @@
 .footerPadding {
   padding: 13px 20px 13px 18px;
 }
+.noVotesContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
 .noVotesMessage {
   text-align: center;
   margin-bottom: 0px;

--- a/packages/prop-house-webapp/src/components/ProposalModalFooter/ProposalModalFooter.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalFooter/ProposalModalFooter.module.css
@@ -7,181 +7,17 @@
   border-top: 1px solid rgba(0, 0, 0, 0.04) !important;
   width: 100%;
   max-width: 100%;
-  min-height: 68px;
 }
 .footerPadding {
   padding: 13px 20px 13px 18px;
 }
-.footerPadding {
-  text-align: center;
-}
 
-.votingContainer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.votingBarAndTooltip {
-  display: flex;
-  width: 65%;
-  gap: 20px;
-  justify-content: space-between;
-}
-.votingProgressBar,
-.voteAllotmentSection {
-  width: 100%;
-}
-.voteAllotmentSection {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 5px;
-}
-.icon {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  color: var(--brand-gray);
-}
-.icon span {
-  color: var(--brand-gray-transparent) !important;
-}
-.votingInfo {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  font-size: 14px;
-  margin-bottom: 5px;
-}
-.totalVotes {
-  color: var(--brand-gray);
-  display: flex;
-  gap: 5px;
-}
-.totalVotes svg {
-  color: var(--brand-gray-transparent);
-}
-.submitVotesButton {
-  font-size: 14px !important;
-  padding: 4px 12px !important;
-  line-height: 18px !important;
-}
-
-@media (max-width: 992px) {
-  .voteAllotmentSection {
-    width: 66%;
-  }
-}
-@media (max-width: 767px) {
-  .votingProgressBar,
-  .voteAllotmentSection {
-    width: 50%;
-  }
-}
-@media (max-width: 700px) {
-  .icon,
-  .crownNoun {
-    display: none !important;
-  }
-}
-@media (max-width: 767px) {
-  .votingProgressBar {
-    width: 40%;
-    width: 100%;
-  }
-  .votingBarAndTooltip {
-    width: 50%;
-  }
-}
-
-@media (min-width: 576px) {
-  .btnContainer {
-    display: none !important;
-  }
-  .fullWidthButton {
-    min-width: 200px;
-  }
-}
-.backBtnContainer {
-  display: flex;
-  gap: 5px;
-  align-items: center;
-  font-weight: 700;
-  color: var(--brand-gray);
-}
-@media (max-width: 577px) {
-  .backBtnContainer {
-    padding-bottom: 25px;
-  }
-}
-.propNavigationButtons {
-  display: flex;
-  gap: 2px;
-}
-.propNavigationButtons button {
-  border: 1.5px solid rgba(102, 102, 102, 0.25);
-  padding: 0;
-  background-color: white;
-  color: black;
-  border-color: rgba(0, 0, 0, 0.1);
-  width: 34px;
-  height: 34px;
-}
-.propNavigationButtons button:disabled {
-  background: var(--border-light);
-}
-.propNavigationButtons button:disabled svg {
-  color: var(--brand-gray-transparent);
-}
-.propNavigationButtons button svg {
-  padding: 4px;
-}
-.propNavigationButtons button:first-child {
-  border-radius: 10px 4px 4px 10px;
-}
-.propNavigationButtons button:nth-child(2) {
-  border-radius: 4px 10px 10px 4px;
-}
-
-.propNavigationButtons {
-  gap: 5px;
-}
-.propNavigationButtons button {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  justify-content: center;
-  font-weight: 700;
-  padding: 10px;
-  height: 38px;
-}
-.crownNoun {
-  display: flex;
-}
-.crownNoun img {
-  height: 14px;
-}
 @media (max-width: 575px) {
-  .votingProgressBar,
-  .votingBarAndTooltip,
-  .icon {
-    display: none !important;
-  }
-  .voteAllotmentSection {
-    width: 100%;
-    justify-content: space-between;
-  }
-  .submitVotesButton {
-    height: 38px;
-  }
   .footerContainer {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     min-height: auto;
-  }
-  .btnContainer {
-    padding: 0px 12px 12px 12px;
   }
   .footerPadding .btnContainer {
     padding: 10px 0px 0px 0px;
@@ -189,4 +25,23 @@
   .fullWidthButton {
     width: 100%;
   }
+  .voteCount {
+    display: none !important;
+  }
+}
+.crownNoun {
+  display: flex;
+}
+.crownNoun img {
+  height: 14px;
+}
+.voteCount {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.connectContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }

--- a/packages/prop-house-webapp/src/components/ProposalModalFooter/ProposalModalFooter.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalFooter/ProposalModalFooter.module.css
@@ -11,6 +11,10 @@
 .footerPadding {
   padding: 13px 20px 13px 18px;
 }
+.noVotesMessage {
+  text-align: center;
+  margin-bottom: 0px;
+}
 
 @media (max-width: 575px) {
   .footerContainer {

--- a/packages/prop-house-webapp/src/components/ProposalModalFooter/ProposalModalFooter.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalFooter/ProposalModalFooter.module.css
@@ -78,9 +78,10 @@
     width: 50%;
   }
 }
-@media (max-width: 650px) {
-  .icon {
-    display: none;
+@media (max-width: 700px) {
+  .icon,
+  .crownNoun {
+    display: none !important;
   }
 }
 @media (max-width: 767px) {
@@ -154,7 +155,12 @@
   padding: 10px;
   height: 38px;
 }
-
+.crownNoun {
+  display: flex;
+}
+.crownNoun img {
+  height: 14px;
+}
 @media (max-width: 575px) {
   .votingProgressBar,
   .votingBarAndTooltip,

--- a/packages/prop-house-webapp/src/components/ProposalModalFooter/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalModalFooter/index.tsx
@@ -14,6 +14,7 @@ import WinningProposalBanner from '../WinningProposalBanner/WinningProposalBanne
 import ProposalModalVotingModule from '../ProposalModalVotingModule';
 import ProposalModalNavButtons from '../ProposalModalNavButtons';
 import VotesDisplay from '../VotesDisplay';
+import { useTranslation } from 'react-i18next';
 
 const ProposalModalFooter: React.FC<{
   setShowVotingModal: Dispatch<SetStateAction<boolean>>;
@@ -36,6 +37,7 @@ const ProposalModalFooter: React.FC<{
   const { account, library } = useEthers();
   const connect = useWeb3Modal();
   const dispatch = useDispatch();
+  const { t } = useTranslation();
 
   const community = useAppSelector(state => state.propHouse.activeCommunity);
   const round = useAppSelector(state => state.propHouse.activeRound);
@@ -111,14 +113,23 @@ const ProposalModalFooter: React.FC<{
                 )}
 
                 {/* VOTING PERIOD, CONNECTED, HAS VOTES */}
-                {account && isVotingWindow && votingPower
-                  ? <ProposalModalVotingModule
-                    proposal={proposal}
-                    setShowVotingModal={setShowVotingModal}
-                    setShowVoteAllotmentModal={setShowVoteAllotmentModal}
-                    isWinner={isWinner && isWinner}
-                  />
-                  : <></>}
+                {account &&
+                  (isVotingWindow && votingPower > 0 ?
+                    <ProposalModalVotingModule
+                      proposal={proposal}
+                      setShowVotingModal={setShowVotingModal}
+                      setShowVoteAllotmentModal={setShowVoteAllotmentModal}
+                      isWinner={isWinner && isWinner}
+                    />
+                    :
+                    <>
+                      <p className={classes.noVotesMessage}>
+                        <b>
+                          {t('youDontHaveAny')} {community?.name ?? 'tokens'} {t('requiredToVote')}.
+                        </b>
+                      </p>
+                    </>)
+                }
               </div>
             )}
           </>

--- a/packages/prop-house-webapp/src/components/ProposalModalFooter/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalModalFooter/index.tsx
@@ -3,8 +3,6 @@ import classes from './ProposalModalFooter.module.css';
 import clsx from 'clsx';
 import PropCardVotingModule from '../PropCardVotingModule';
 import Button, { ButtonColor } from '../Button';
-import { MdHowToVote as VoteIcon } from 'react-icons/md';
-import TruncateThousands from '../TruncateThousands';
 import { voteWeightForAllottedVotes } from '../../utils/voteWeightForAllottedVotes';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { ImArrowLeft2, ImArrowRight2 } from 'react-icons/im';
@@ -21,6 +19,7 @@ import { aggVoteWeightForProps } from '../../utils/aggVoteWeight';
 import { useNavigate } from 'react-router-dom';
 import WinningProposalBanner from '../WinningProposalBanner/WinningProposalBanner';
 import VoteAllotmentTooltip from '../VoteAllotmentTooltip';
+import VotesDisplay from '../VotesDisplay';
 
 const ProposalModalFooter: React.FC<{
   setShowVotingModal: Dispatch<SetStateAction<boolean>>;
@@ -162,8 +161,12 @@ const ProposalModalFooter: React.FC<{
                     </div>
 
                     <div className={classes.voteAllotmentSection}>
+                      {isWinner && <div className={classes.crownNoun}>
+                        <img src="/heads/crown.png" alt="crown" />
+                      </div>}
+
                       <div className={classes.icon}>
-                        <VoteIcon /> <TruncateThousands amount={proposal.voteCount} /> <span>+</span>
+                        <VotesDisplay proposal={proposal} /> <span>+</span>
                       </div>
 
                       <div className="mobileTooltipContainer">

--- a/packages/prop-house-webapp/src/components/ProposalModalFooter/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalModalFooter/index.tsx
@@ -96,7 +96,8 @@ const ProposalModalFooter: React.FC<{
                       {!isProposingWindow && <div className={classes.icon}>
                         <VotesDisplay proposal={proposal} />
                       </div>}
-                    </div></div>
+                    </div>
+                  </div>
                 )}
 
 
@@ -123,11 +124,23 @@ const ProposalModalFooter: React.FC<{
                     />
                     :
                     <>
-                      <p className={classes.noVotesMessage}>
-                        <b>
-                          {t('youDontHaveAny')} {community?.name ?? 'tokens'} {t('requiredToVote')}.
-                        </b>
-                      </p>
+                      <div className={classes.noVotesContainer}>
+                        <p className={classes.noVotesMessage}>
+                          <b>
+                            {t('youDontHaveAny')} {community?.name ?? 'tokens'} {t('requiredToVote')}.
+                          </b>
+                        </p>
+
+                        <div className={classes.voteCount}>
+                          {isWinner && <div className={classes.crownNoun}>
+                            <img src="/heads/crown.png" alt="crown" />
+                          </div>}
+
+                          <div className={classes.icon}>
+                            <VotesDisplay proposal={proposal} />
+                          </div>
+                        </div>
+                      </div>
                     </>)
                 }
               </div>

--- a/packages/prop-house-webapp/src/components/ProposalModalHeader/ProposalModalHeader.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalHeader/ProposalModalHeader.module.css
@@ -8,7 +8,12 @@
   flex-direction: column;
   max-width: 75%;
 }
-
+.crownNoun {
+  display: flex;
+}
+.crownNoun img {
+  height: 14px;
+}
 .creditDash {
   font-weight: 500;
   color: var(--brand-black-semi-transparent);

--- a/packages/prop-house-webapp/src/components/ProposalModalHeader/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalModalHeader/index.tsx
@@ -1,8 +1,9 @@
 import classes from './ProposalModalHeader.module.css';
 import EthAddress from '../EthAddress';
 import { ImArrowLeft2, ImArrowRight2 } from 'react-icons/im';
-import { Direction } from '@nouns/prop-house-wrapper/dist/builders';
+import { Direction, StoredProposalWithVotes } from '@nouns/prop-house-wrapper/dist/builders';
 import { useCallback, useEffect } from 'react';
+import VotesDisplay from '../VotesDisplay';
 
 export interface ProposalModalHeaderProps {
   fieldTitle: string;
@@ -15,6 +16,7 @@ export interface ProposalModalHeaderProps {
   isFirstProp: boolean;
   isLastProp: boolean | undefined;
   showVoteAllotmentModal: boolean;
+  proposal: StoredProposalWithVotes;
 }
 
 const ProposalModalHeader: React.FC<ProposalModalHeaderProps> = props => {
@@ -29,6 +31,7 @@ const ProposalModalHeader: React.FC<ProposalModalHeaderProps> = props => {
     isFirstProp,
     isLastProp,
     showVoteAllotmentModal,
+    proposal
   } = props;
 
   const handleKeyPress = useCallback(
@@ -57,13 +60,15 @@ const ProposalModalHeader: React.FC<ProposalModalHeaderProps> = props => {
           <div className={classes.subinfo}>
             <div className={classes.communityAndPropNumber}>
               <span className={classes.propNumber}>
-                Prop {propIndex} of {numberOfProps}
+                Prop {propIndex} of {numberOfProps} by
               </span>{' '}
-              <span className={classes.creditDash}>—</span>
-              <span className={classes.propCredit}>#{proposalId} by</span>
               <div className={classes.submittedBy}>
                 <EthAddress address={address} hideDavatar={true} className={classes.submittedBy} />
               </div>
+              <span className={classes.creditDash}>
+                —
+              </span>
+              <VotesDisplay proposal={proposal} />
             </div>
           </div>
         )}

--- a/packages/prop-house-webapp/src/components/ProposalModalHeader/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalModalHeader/index.tsx
@@ -3,7 +3,6 @@ import EthAddress from '../EthAddress';
 import { ImArrowLeft2, ImArrowRight2 } from 'react-icons/im';
 import { Direction, StoredProposalWithVotes } from '@nouns/prop-house-wrapper/dist/builders';
 import { useCallback, useEffect } from 'react';
-import VotesDisplay from '../VotesDisplay';
 
 export interface ProposalModalHeaderProps {
   fieldTitle: string;
@@ -31,9 +30,8 @@ const ProposalModalHeader: React.FC<ProposalModalHeaderProps> = props => {
     isFirstProp,
     isLastProp,
     showVoteAllotmentModal,
-    proposal
-  } = props;
 
+  } = props;
   const handleKeyPress = useCallback(
     event => {
       if (event.key === 'ArrowLeft' && !isFirstProp && !showVoteAllotmentModal) {
@@ -58,17 +56,20 @@ const ProposalModalHeader: React.FC<ProposalModalHeaderProps> = props => {
       <div className={classes.headerPropInfo}>
         {address && proposalId && (
           <div className={classes.subinfo}>
+
             <div className={classes.communityAndPropNumber}>
               <span className={classes.propNumber}>
-                Prop {propIndex} of {numberOfProps} by
+                Prop {propIndex} of {numberOfProps}
+                {' '}<span className={classes.creditDash}>
+                  —
+                </span>
+                {" "}by{" "}
               </span>{' '}
               <div className={classes.submittedBy}>
                 <EthAddress address={address} hideDavatar={true} className={classes.submittedBy} />
               </div>
-              <span className={classes.creditDash}>
-                —
-              </span>
-              <VotesDisplay proposal={proposal} />
+
+
             </div>
           </div>
         )}

--- a/packages/prop-house-webapp/src/components/ProposalModalNavButtons/ProposalModalNavButtons.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalNavButtons/ProposalModalNavButtons.module.css
@@ -1,0 +1,51 @@
+@media (min-width: 576px) {
+  .btnContainer {
+    display: none !important;
+  }
+}
+.propNavigationButtons {
+  display: flex;
+  gap: 2px;
+}
+.propNavigationButtons button {
+  border: 1.5px solid rgba(102, 102, 102, 0.25);
+  padding: 0;
+  background-color: white;
+  color: black;
+  border-color: rgba(0, 0, 0, 0.1);
+  width: 34px;
+  height: 34px;
+}
+.propNavigationButtons button:disabled {
+  background: var(--border-light);
+}
+.propNavigationButtons button:disabled svg {
+  color: var(--brand-gray-transparent);
+}
+.propNavigationButtons button svg {
+  padding: 4px;
+}
+.propNavigationButtons button:first-child {
+  border-radius: 10px 4px 4px 10px;
+}
+.propNavigationButtons button:nth-child(2) {
+  border-radius: 4px 10px 10px 4px;
+}
+.propNavigationButtons {
+  gap: 5px;
+}
+.propNavigationButtons button {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  padding: 10px;
+  height: 38px;
+}
+
+@media (max-width: 575px) {
+  .btnContainer {
+    padding: 0px 20px 20px 20px;
+  }
+}

--- a/packages/prop-house-webapp/src/components/ProposalModalNavButtons/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalModalNavButtons/index.tsx
@@ -1,0 +1,36 @@
+import classes from './ProposalModalNavButtons.module.css';
+import { ImArrowLeft2, ImArrowRight2 } from 'react-icons/im';
+import { Direction } from '@nouns/prop-house-wrapper/dist/builders';
+
+const ProposalModalNavButtons: React.FC<{
+  propIndex: number | undefined;
+  numberOfProps: number;
+  handleDirectionalArrowClick: (e: any) => void;
+}> = props => {
+  const { propIndex, numberOfProps, handleDirectionalArrowClick } = props;
+
+  return (
+    <>
+      <div className={classes.btnContainer}>
+        <div className={classes.propNavigationButtons}>
+          <button
+            disabled={propIndex === 1}
+            onClick={() => handleDirectionalArrowClick(Direction.Down)}
+          >
+            <ImArrowLeft2 size={'1.5rem'} />
+            <span>Back</span>
+          </button>
+
+          <button
+            onClick={() => handleDirectionalArrowClick(Direction.Up)}
+            disabled={propIndex === numberOfProps}
+          >
+            <span>Next</span> <ImArrowRight2 size={'1.5rem'} />
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ProposalModalNavButtons;

--- a/packages/prop-house-webapp/src/components/ProposalModalVotingModule/ProposalModalVotingModule.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalVotingModule/ProposalModalVotingModule.module.css
@@ -1,0 +1,97 @@
+.votingContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.votingBarAndTooltip {
+  display: flex;
+  width: 65%;
+  gap: 20px;
+  justify-content: space-between;
+}
+.votingProgressBar,
+.voteAllotmentSection {
+  width: 100%;
+}
+.voteAllotmentSection {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+}
+.icon {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--brand-gray);
+}
+.icon span {
+  color: var(--brand-gray-transparent) !important;
+}
+.votingInfo {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 14px;
+  margin-bottom: 5px;
+}
+.totalVotes {
+  color: var(--brand-gray);
+  display: flex;
+  gap: 5px;
+}
+.totalVotes svg {
+  color: var(--brand-gray-transparent);
+}
+.submitVotesButton {
+  font-size: 14px !important;
+  padding: 4px 12px !important;
+  line-height: 18px !important;
+}
+.crownNoun {
+  display: flex;
+}
+.crownNoun img {
+  height: 14px;
+}
+@media (max-width: 992px) {
+  .voteAllotmentSection {
+    width: 66%;
+  }
+}
+@media (max-width: 767px) {
+  .votingProgressBar,
+  .voteAllotmentSection {
+    width: 50%;
+  }
+}
+@media (max-width: 700px) {
+  .icon,
+  .crownNoun {
+    display: none !important;
+  }
+}
+@media (max-width: 767px) {
+  .votingProgressBar {
+    width: 40%;
+    width: 100%;
+  }
+  .votingBarAndTooltip {
+    width: 50%;
+  }
+}
+
+@media (max-width: 575px) {
+  .votingProgressBar,
+  .votingBarAndTooltip,
+  .icon {
+    display: none !important;
+  }
+  .voteAllotmentSection {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .submitVotesButton {
+    height: 38px;
+  }
+}

--- a/packages/prop-house-webapp/src/components/ProposalModalVotingModule/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalModalVotingModule/index.tsx
@@ -1,0 +1,136 @@
+import { ProgressBar } from 'react-bootstrap';
+import classes from './ProposalModalVotingModule.module.css';
+import clsx from 'clsx';
+import PropCardVotingModule from '../PropCardVotingModule';
+import Button, { ButtonColor } from '../Button';
+import { voteWeightForAllottedVotes } from '../../utils/voteWeightForAllottedVotes';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { useEthers } from '@usedapp/core';
+import { useAppSelector } from '../../hooks';
+import { votesRemaining } from '../../utils/votesRemaining';
+import { useDispatch } from 'react-redux';
+import { getNumVotes } from 'prop-house-communities';
+import { setNumSubmittedVotes, setVotingPower } from '../../state/slices/voting';
+import { aggVoteWeightForProps } from '../../utils/aggVoteWeight';
+import VoteAllotmentTooltip from '../VoteAllotmentTooltip';
+import { StoredProposalWithVotes } from '@nouns/prop-house-wrapper/dist/builders';
+import VotesDisplay from '../VotesDisplay';
+
+const ProposalModalFooter: React.FC<{
+  proposal: StoredProposalWithVotes;
+  setShowVotingModal: Dispatch<SetStateAction<boolean>>;
+  setShowVoteAllotmentModal: Dispatch<SetStateAction<boolean>>;
+  isWinner?: boolean;
+}> = props => {
+  const { proposal, setShowVotingModal, setShowVoteAllotmentModal, isWinner } = props;
+
+  const { account, library } = useEthers();
+  const dispatch = useDispatch();
+
+  const community = useAppSelector(state => state.propHouse.activeCommunity);
+  const round = useAppSelector(state => state.propHouse.activeRound);
+  const proposals = useAppSelector(state => state.propHouse.activeProposals);
+
+  const votingPower = useAppSelector(state => state.voting.votingPower);
+  const voteAllotments = useAppSelector(state => state.voting.voteAllotments);
+  const submittedVotes = useAppSelector(state => state.voting.numSubmittedVotes);
+
+  const [votesLeftToAllot, setVotesLeftToAllot] = useState(0);
+  const [numAllotedVotes, setNumAllotedVotes] = useState(0);
+
+  useEffect(() => {
+    if (!account || !library || !community) return;
+
+    const fetchVotes = async () => {
+      try {
+        const votes = await getNumVotes(
+          account,
+          community.contractAddress,
+          library,
+          round!.balanceBlockTag,
+        );
+        dispatch(setVotingPower(votes));
+      } catch (e) {
+        console.log('error fetching votes: ', e);
+      }
+    };
+    fetchVotes();
+  }, [account, library, dispatch, community, round]);
+
+  // update submitted votes on proposal changes
+  useEffect(() => {
+    if (proposals && account)
+      dispatch(setNumSubmittedVotes(aggVoteWeightForProps(proposals, account)));
+  }, [proposals, account, dispatch]);
+
+  useEffect(() => {
+    setVotesLeftToAllot(votesRemaining(votingPower, submittedVotes, voteAllotments));
+    setNumAllotedVotes(voteWeightForAllottedVotes(voteAllotments));
+  }, [submittedVotes, voteAllotments, votingPower]);
+
+  return (
+    <>
+      <div className={classes.votingContainer}>
+        <div className={classes.votingBarAndTooltip}>
+          <div className={classes.votingProgressBar}>
+            <div className={classes.votingInfo}>
+              <span>Cast your votes</span>
+
+              <span className={classes.totalVotes}>
+                <VoteAllotmentTooltip
+                  setShowVoteAllotmentModal={setShowVoteAllotmentModal}
+                />
+
+                {`${votesLeftToAllot > 0
+                  ? `${votingPower - submittedVotes - numAllotedVotes} left`
+                  : 'no votes left'
+                  }`}
+              </span>
+            </div>
+
+            <ProgressBar
+              className={clsx(
+                classes.votingBar,
+                submittedVotes > 0 && votingPower !== submittedVotes && 'roundAllotmentBar',
+              )}
+            >
+              <ProgressBar variant="success" now={(submittedVotes / votingPower) * 100} />
+
+              <ProgressBar variant="warning" now={(numAllotedVotes / votingPower) * 100} key={2} />
+            </ProgressBar>
+          </div>
+        </div>
+
+        <div className={classes.voteAllotmentSection}>
+          {isWinner && <div className={classes.crownNoun}>
+            <img src="/heads/crown.png" alt="crown" />
+          </div>}
+
+          <div className={classes.icon}>
+            <VotesDisplay proposal={proposal} /> <span>+</span>
+          </div>
+
+          <div className="mobileTooltipContainer">
+            <PropCardVotingModule proposal={proposal} />
+
+            <VoteAllotmentTooltip
+              setShowVoteAllotmentModal={setShowVoteAllotmentModal}
+            />
+          </div>
+
+          <Button
+            classNames={classes.submitVotesButton}
+            text={'Submit votes'}
+            bgColor={ButtonColor.Purple}
+            disabled={
+              voteWeightForAllottedVotes(voteAllotments) === 0 || submittedVotes === votingPower
+            }
+            onClick={() => setShowVotingModal(true)}
+          />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ProposalModalFooter;

--- a/packages/prop-house-webapp/src/components/RoundContent/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundContent/index.tsx
@@ -185,7 +185,7 @@ const RoundContent: React.FC<{
                             proposal={proposal}
                             auctionStatus={auctionStatus(auction)}
                             cardStatus={cardStatus(votingPower > 0, auction)}
-                            winner={winningIds && isWinner(winningIds, proposal.id)}
+                            isWinner={winningIds && isWinner(winningIds, proposal.id)}
                           />
                         </Col>
                       );

--- a/packages/prop-house-webapp/src/components/RoundOverModule/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundOverModule/index.tsx
@@ -20,12 +20,12 @@ const RoundOverModule: React.FC<RoundOverModuleProps> = (props: RoundOverModuleP
         </div>
         <div className={classes.textContainer}>
           <p className={classes.title}>{t('votingEnded')}</p>
-          {numOfProposals && (
+          {numOfProposals ? (
             <p className={classes.subtitle}>
               {totalVotes?.toFixed()} {Number(totalVotes?.toFixed()) === 1 ? t('vote') : t('votes')}{' '}
               {t('castFor')} {numOfProposals} {numOfProposals === 1 ? t('prop') : t('props')}!
             </p>
-          )}
+          ) : <></>}
         </div>
       </div>
 

--- a/packages/prop-house-webapp/src/components/VotesDisplay/VotesDisplay.module.css
+++ b/packages/prop-house-webapp/src/components/VotesDisplay/VotesDisplay.module.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  color: var(--brand-gray) !important;
 }
 .scoreAndIcon:hover {
   cursor: pointer;

--- a/packages/prop-house-webapp/src/components/VotesDisplay/VotesDisplay.module.css
+++ b/packages/prop-house-webapp/src/components/VotesDisplay/VotesDisplay.module.css
@@ -3,3 +3,6 @@
   align-items: center;
   gap: 4px;
 }
+.scoreAndIcon:hover {
+  cursor: pointer;
+}

--- a/packages/prop-house-webapp/src/css/globals.css
+++ b/packages/prop-house-webapp/src/css/globals.css
@@ -223,7 +223,7 @@ body {
   left: 0;
   right: 0;
   top: 300px;
-  bottom: 60px;
+  bottom: 0px;
   background: linear-gradient(0deg, rgba(255, 255, 255, 1) 0%, rgba(0, 0, 0, 0) 100%);
 }
 @media (max-width: 575px) {

--- a/packages/prop-house-webapp/src/utils/getWinningIds.ts
+++ b/packages/prop-house-webapp/src/utils/getWinningIds.ts
@@ -5,7 +5,11 @@ const getWinningIds = (
   proposals: StoredProposalWithVotes[] | undefined,
   auction: StoredAuction,
 ) => {
-  if (auctionStatus(auction) !== AuctionStatus.AuctionEnded) return;
+  if (
+    auctionStatus(auction) === AuctionStatus.AuctionAcceptingProps ||
+    auctionStatus(auction) === AuctionStatus.AuctionNotStarted
+  )
+    return;
 
   // empty array to store
   const winningIds: number[] = [];


### PR DESCRIPTION
### During the voting stage, users will now be able to see which props _are currently winning_. On the round page they will have a crown next to their titles but said titles will still be black. 
<img width="350" alt="Screenshot 2022-12-16 at 10 48 38 AM" src="https://user-images.githubusercontent.com/26611339/208136251-79868499-9add-4bac-8217-7815d9245998.png">

### Once the round is over and we have official winners their titles will be green
<img width="606" alt="Screenshot 2022-12-16 at 10 49 41 AM" src="https://user-images.githubusercontent.com/26611339/208136431-0487e56b-57b2-4759-9d65-52b2a55119bc.png">


### In the Prop Modal, whether you are wallet connected or not you will see the props current vote count & a crown if they are winning. 
<img width="1340" alt="Screenshot 2022-12-16 at 10 51 29 AM" src="https://user-images.githubusercontent.com/26611339/208136802-4792618b-00c5-4d84-bb5c-bbde7687d5e4.png">

### If you connect your wallet during the voting stage, but don't have votes in this round, you will now see a message saying so
<img width="1032" alt="Screenshot 2022-12-16 at 11 02 13 AM" src="https://user-images.githubusercontent.com/26611339/208139270-8aafb30e-a694-412a-a34a-7f97f2f082f2.png">


### In the Prop Modal, we removed the prop id
<img width="633" alt="Screenshot 2022-12-16 at 10 53 38 AM" src="https://user-images.githubusercontent.com/26611339/208137278-7c8eb8d5-e486-44de-8d97-c0bdb34fbc38.png">

