### PR TITLE
Sort winning props that tie by created date

### DIFF
--- a/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
@@ -34,7 +34,7 @@
   display: flex;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   word-break: break-word;
 }

--- a/packages/prop-house-webapp/src/utils/getWinningIds.ts
+++ b/packages/prop-house-webapp/src/utils/getWinningIds.ts
@@ -1,4 +1,5 @@
 import { StoredAuction, StoredProposalWithVotes } from '@nouns/prop-house-wrapper/dist/builders';
+import dayjs from 'dayjs';
 import { AuctionStatus, auctionStatus } from './auctionStatus';
 
 const getWinningIds = (
@@ -14,12 +15,19 @@ const getWinningIds = (
   // empty array to store
   const winningIds: number[] = [];
 
-  proposals &&
-    proposals
-      .slice()
-      .sort((a, b) => (Number(a.voteCount) < Number(b.voteCount) ? 1 : -1))
-      .slice(0, auction.numWinners)
-      .map(p => winningIds.push(p.id));
+  const sortedProposals =
+    proposals &&
+    proposals.slice().sort((a, b) => {
+      if (Number(a.voteCount) > Number(b.voteCount)) {
+        return -1;
+      } else if (Number(a.voteCount) < Number(b.voteCount)) {
+        return 1;
+      } else {
+        // If the vote counts are equal, sort by created date from oldest to newest
+        return (dayjs(a.createdDate) as any) - (dayjs(b.createdDate) as any);
+      }
+    });
+  sortedProposals && sortedProposals.slice(0, auction.numWinners).map(p => winningIds.push(p.id));
 
   return winningIds;
 };


### PR DESCRIPTION
This PR updates how we handle ties. If there's a tie between proposals, the earliest submitted proposal wins.