### PR TITLE
Remaining Vote Calculation Bug Fix

### DIFF
--- a/packages/prop-house-webapp/src/components/RoundContent/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundContent/index.tsx
@@ -12,7 +12,7 @@ import { useDispatch } from 'react-redux';
 import { useAppSelector } from '../../hooks';
 import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
 import { refreshActiveProposals } from '../../utils/refreshActiveProposal';
-import { aggVoteWeightForProps } from '../../utils/aggVoteWeight';
+import { aggValidatedVoteWeightForProps } from '../../utils/aggVoteWeight';
 import { setActiveProposals } from '../../state/slices/propHouse';
 import { dispatchSortProposals, SortType } from '../../utils/sortingProposals';
 import { getNumVotes } from 'prop-house-communities';
@@ -112,7 +112,7 @@ const RoundContent: React.FC<{
   // update submitted votes on proposal changes
   useEffect(() => {
     if (proposals && account)
-      dispatch(setNumSubmittedVotes(aggVoteWeightForProps(proposals, account)));
+      dispatch(setNumSubmittedVotes(aggValidatedVoteWeightForProps(proposals, account)));
   }, [proposals, account, dispatch]);
 
   const _signerIsContract = async () => {

--- a/packages/prop-house-webapp/src/utils/aggVoteWeight.ts
+++ b/packages/prop-house-webapp/src/utils/aggVoteWeight.ts
@@ -1,12 +1,18 @@
-import { StoredProposalWithVotes, StoredVote } from '@nouns/prop-house-wrapper/dist/builders';
+import { SignatureState, StoredProposalWithVotes, StoredVote } from '@nouns/prop-house-wrapper/dist/builders';
 import extractAllVotes from './extractAllVotes';
 
 /**
- * Calculates aggregate vote weight for votes extracted from a set of proposals
+ * Calculates aggregate validated vote weight for votes extracted from a set of proposals
  */
-export const aggVoteWeightForProps = (proposals: StoredProposalWithVotes[], address: string) =>
+export const aggValidatedVoteWeightForProps = (proposals: StoredProposalWithVotes[], address: string) =>
   extractAllVotes(proposals, address).reduce(
-    (agg, current) => Number(agg) + Number(current.weight),
+    (agg, current) => {
+      // Only validated votes should count towards remaining vote weight
+      if (current.signatureState !== SignatureState.VALIDATED) {
+        return agg;
+      }
+      return Number(agg) + Number(current.weight);
+    },
     0,
   );
 


### PR DESCRIPTION
This PR updates the remaining vote calculation to only deduct **validated** votes. Votes that are pending validation or have failed validation should be disregarded.