### PR TITLE
Prevent line break within status pill

### DIFF
--- a/packages/prop-house-webapp/src/components/StatusPill/StatusPill.module.css
+++ b/packages/prop-house-webapp/src/components/StatusPill/StatusPill.module.css
@@ -1,12 +1,13 @@
 .pillContainer {
   display: inline-block;
-  /* margin: 0rem 0.75rem; */
   padding: 2.5px 0.5rem;
   border-radius: 10px;
   position: relative;
   right: -8px;
   font-size: 14px;
   font-weight: 600;
+  min-width: max-content;
+  align-self: flex-start;
 }
 @media (max-width: 497px) {
   .pillContainer {


### PR DESCRIPTION
If the Round title is long and pushed against a "Not Started" status pill it made the words break to two lines. By setting the minimum width of the text to the max content of said copy we prevent the line-break within the pill.

### Before
<img width="352" alt="Screenshot 2022-12-28 at 8 04 05 PM" src="https://user-images.githubusercontent.com/26611339/209890461-b5330cd4-20a5-482f-93c7-d63e0b850d20.png">


### After
<img width="345" alt="Screenshot 2022-12-28 at 8 03 43 PM" src="https://user-images.githubusercontent.com/26611339/209890437-083159d3-06d2-459f-a2cf-4d4d94723a46.png">
