### PR TITLE
Hotfix: Truncate long ENS

### DIFF
--- a/packages/prop-house-webapp/src/components/ProposalSuccessModal/ProposalSuccessModal.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalSuccessModal/ProposalSuccessModal.module.css
@@ -55,6 +55,15 @@
   justify-content: center;
   padding-bottom: 5px;
 }
+.modalTitle div {
+  max-width: 70%;
+}
+.modalTitle span {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  display: block;
+  overflow: hidden;
+}
 .address {
   font-weight: 700;
   font-size: 22px;


### PR DESCRIPTION
If there's an incredibly long ENS address we should truncate it and use ellipsis

<img width="531" alt="Screenshot 2023-01-06 at 12 22 53 PM" src="https://user-images.githubusercontent.com/26611339/211064495-febfb1b2-933d-415c-bcef-438fcfd6587e.png">
