### PR TITLE
Shorten clickable area to button length

### DIFF
--- a/packages/prop-house-webapp/src/components/ReadMore/ReadMore.module.css
+++ b/packages/prop-house-webapp/src/components/ReadMore/ReadMore.module.css
@@ -6,6 +6,7 @@
   color: var(--brand-pink) !important;
   text-decoration: underline;
   font-weight: 600;
+  width: max-content;
 }
 .readMoreLessButton:hover {
   cursor: pointer;


### PR DESCRIPTION
The clickable area of the "Read More" button was the full-width of the page. We should restrict this to the width of the word's themselves. Top was before, bottom is after.

<img width="1039" alt="Screenshot 2023-01-10 at 6 27 20 AM" src="https://user-images.githubusercontent.com/26611339/211540641-850ccd08-3edf-41a9-a60c-c869f5ffef4e.png">
