### PR TITLE
Extract code to util funcs

### DIFF
--- a/packages/prop-house-webapp/src/components/ForceOpenInNewTab/index.tsx
+++ b/packages/prop-house-webapp/src/components/ForceOpenInNewTab/index.tsx
@@ -1,0 +1,9 @@
+
+interface ForceOpenInNewTabProps {
+  children: React.ReactNode;
+}
+
+// overrides an <a> tag that doesn't have target="_blank" and adds it
+export const ForceOpenInNewTab = ({ children, ...props }: ForceOpenInNewTabProps) => (
+  <a {...props}>{children}</a>
+);

--- a/packages/prop-house-webapp/src/components/HouseHeader/index.tsx
+++ b/packages/prop-house-webapp/src/components/HouseHeader/index.tsx
@@ -10,15 +10,8 @@ import sanitizeHtml from 'sanitize-html';
 import Markdown from 'markdown-to-jsx';
 import { isMobile } from 'web3modal';
 import ReadMore from '../ReadMore';
-
-const isLongName = (name: string) => name.length > 9;
-
-interface OpenInNewTabProps {
-  children: React.ReactNode;
-}
-
-// overrides an <a> tag that doesn't have target="_blank" and adds it
-const OpenInNewTab = ({ children, ...props }: OpenInNewTabProps) => <a {...props}>{children}</a>;
+import { isLongName } from '../../utils/isLongName';
+import { ForceOpenInNewTab } from '../ForceOpenInNewTab';
 
 const HouseHeader: React.FC<{
   community: Community;
@@ -34,7 +27,7 @@ const HouseHeader: React.FC<{
         options={{
           overrides: {
             a: {
-              component: OpenInNewTab,
+              component: ForceOpenInNewTab,
               props: {
                 target: '_blank',
                 rel: 'noreferrer',
@@ -52,7 +45,6 @@ const HouseHeader: React.FC<{
       </Markdown>
     </div>
   );
-
 
   const { t } = useTranslation();
 

--- a/packages/prop-house-webapp/src/components/RoundHeader/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundHeader/index.tsx
@@ -9,15 +9,8 @@ import { useNavigate } from 'react-router-dom';
 import formatTime from '../../utils/formatTime';
 import { nameToSlug } from '../../utils/communitySlugs';
 import ReadMore from '../ReadMore';
-
-const isLongName = (name: string) => name.length > 9;
-
-interface OpenInNewTabProps {
-  children: React.ReactNode;
-}
-
-// overrides an <a> tag that doesn't have target="_blank" and adds it
-const OpenInNewTab = ({ children, ...props }: OpenInNewTabProps) => <a {...props}>{children}</a>;
+import { ForceOpenInNewTab } from '../ForceOpenInNewTab';
+import { isLongName } from '../../utils/isLongName';
 
 const RoundHeader: React.FC<{
   community: Community;
@@ -33,7 +26,7 @@ const RoundHeader: React.FC<{
         options={{
           overrides: {
             a: {
-              component: OpenInNewTab,
+              component: ForceOpenInNewTab,
               props: {
                 target: '_blank',
                 rel: 'noreferrer',

--- a/packages/prop-house-webapp/src/components/pages/Create/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Create/index.tsx
@@ -14,19 +14,12 @@ import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
 import isAuctionActive from '../../../utils/isAuctionActive';
 import { ProposalFields } from '../../../utils/proposalFields';
 import useWeb3Modal from '../../../hooks/useWeb3Modal';
-import removeTags from '../../../utils/removeTags';
 import { useTranslation } from 'react-i18next';
 import FundingAmount from '../../FundingAmount';
 import LoadingIndicator from '../../LoadingIndicator';
 import ProposalSuccessModal from '../../ProposalSuccessModal';
 import NavBar from '../../NavBar';
-
-
-const isValidPropData = (data: ProposalFields) =>
-  data.title.length > 4 &&
-  removeTags(data.what).length > 49 &&
-  data.tldr.length > 9 &&
-  data.tldr.length < 121;
+import { isValidPropData } from '../../../utils/isValidPropData';
 
 const Create: React.FC<{}> = () => {
   const { library: provider, account } = useEthers();

--- a/packages/prop-house-webapp/src/utils/isLongName.ts
+++ b/packages/prop-house-webapp/src/utils/isLongName.ts
@@ -1,0 +1,1 @@
+export const isLongName = (name: string) => name.length > 9;

--- a/packages/prop-house-webapp/src/utils/isValidPropData.ts
+++ b/packages/prop-house-webapp/src/utils/isValidPropData.ts
@@ -1,0 +1,8 @@
+import { ProposalFields } from './proposalFields';
+import removeTags from './removeTags';
+
+export const isValidPropData = (data: ProposalFields) =>
+  data.title.length > 4 &&
+  removeTags(data.what).length > 49 &&
+  data.tldr.length > 9 &&
+  data.tldr.length < 121;


### PR DESCRIPTION
Moving some reused code to their own utility functions and one component, declared in two places, to a reusable component. Also this component had the same name as a utility function so I renamed it in the process as well.