### PR TITLE
Filter for ETH

### DIFF
--- a/packages/prop-house-backend/src/community/community.service.ts
+++ b/packages/prop-house-backend/src/community/community.service.ts
@@ -90,6 +90,7 @@ export class CommunitiesService {
       .select('a.id', 'id')
       .addSelect('a.communityId')
       .addSelect('COUNT(a.id)', 'numAuctions')
+      .where('a.currencyType ILIKE :eth', { eth: '%eth%' })
       .addSelect('SUM(a.fundingAmount * a.numWinners)', 'ethFunded')
       .from('auction', 'a')
       .groupBy('a.id');

--- a/packages/prop-house-webapp/src/components/pages/Home/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Home/index.tsx
@@ -45,10 +45,7 @@ const Home = () => {
 
       setCommunities(communities.sort((a, b) => (a.ethFunded < b.ethFunded ? 1 : -1)));
 
-      const accEthFunded = communities
-        .filter((c: any) => c.contractAddress !== '0x7Bd29408f11D2bFC23c34f18275bBf23bB716Bc7')
-        .filter((c: any) => c.contractAddress !== '0x2381b67c6f1cb732fdf8b3b29d3260ec6f7420bc')
-        .reduce((prev, current) => prev + current.ethFunded, 0);
+      const accEthFunded = communities.reduce((prev, current) => prev + current.ethFunded, 0);
       const accRounds = communities.reduce((prev, current) => prev + current.numAuctions, 0);
       const accProps = communities.reduce((prev, current) => prev + current.numProposals, 0);
       setStats({


### PR DESCRIPTION
When aggregating data on communities, filter out any `auction` whose primary funding currency (`currencyType`) does not contain `ETH`.

