### PR TITLE
Hot fix: Add total funded 

### DIFF
--- a/packages/prop-house-backend/src/community/community.service.ts
+++ b/packages/prop-house-backend/src/community/community.service.ts
@@ -75,6 +75,7 @@ export class CommunitiesService {
       .select('c.*')
       .addSelect('SUM(a."numAuctions")', 'numAuctions')
       .addSelect('SUM(a."ethFunded")', 'ethFunded')
+      .addSelect('SUM(a."totalFunded")', 'totalFunded')
       .addSelect('SUM(p."numProposals")', 'numProposals')
       .leftJoin(
         this.auctionCountAndFundingSubquery,
@@ -90,8 +91,11 @@ export class CommunitiesService {
       .select('a.id', 'id')
       .addSelect('a.communityId')
       .addSelect('COUNT(a.id)', 'numAuctions')
-      .where('a.currencyType ILIKE :eth', { eth: '%eth%' })
-      .addSelect('SUM(a.fundingAmount * a.numWinners)', 'ethFunded')
+      .addSelect(
+        `CASE WHEN a.currencyType ILIKE '%eth%' then SUM(a.fundingAmount * a.numWinners) else 0 end`,
+        'ethFunded',
+      )
+      .addSelect('SUM(a.fundingAmount * a.numWinners)', 'totalFunded')
       .from('auction', 'a')
       .groupBy('a.id');
   }

--- a/packages/prop-house-webapp/src/components/CommunityCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/CommunityCard/index.tsx
@@ -21,7 +21,7 @@ const CommunityCard: React.FC<{
           <div className={classes.infoWithSymbol}>
             <div className={classes.infoText}>
               <span className={classes.infoAmount}>
-                <TruncateThousands amount={community.ethFunded} />{' '}
+                <TruncateThousands amount={community.totalFunded} />{' '}
                 {getHouseCurrency(community.contractAddress)}
               </span>{' '}
               <span className={classes.infoCopy}>{t('funded')}</span>

--- a/packages/prop-house-webapp/src/components/OpenGraphHouseCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/OpenGraphHouseCard/index.tsx
@@ -63,7 +63,7 @@ const OpenGraphHouseCard: React.FC = () => {
                 <div className={classes.roundInfo}>
                   <span className={classes.title}>Funded</span>
                   <p className={classes.subtitle}>
-                    <TruncateThousands amount={community.ethFunded ?? 0} />{' '}
+                    <TruncateThousands amount={community.totalFunded ?? 0} />{' '}
                     {getHouseCurrency(community.contractAddress)}
                   </p>
                 </div>

--- a/packages/prop-house-webapp/src/components/pages/Home/index.tsx
+++ b/packages/prop-house-webapp/src/components/pages/Home/index.tsx
@@ -43,7 +43,7 @@ const Home = () => {
       setIsLoading(true);
       const communities = await client.current.getCommunities();
 
-      setCommunities(communities.sort((a, b) => (a.ethFunded < b.ethFunded ? 1 : -1)));
+      setCommunities(communities.sort((a, b) => (a.numProposals < b.numProposals ? 1 : -1)));
 
       const accEthFunded = communities.reduce((prev, current) => prev + current.ethFunded, 0);
       const accRounds = communities.reduce((prev, current) => prev + current.numAuctions, 0);

--- a/packages/prop-house-wrapper/src/builders.ts
+++ b/packages/prop-house-wrapper/src/builders.ts
@@ -255,6 +255,7 @@ export class Community extends Signable {
     public readonly numAuctions: number,
     public readonly numProposals: number,
     public readonly ethFunded: number,
+    public readonly totalFunded: number,
     public readonly description: number,
   ) {
     super();
@@ -269,6 +270,7 @@ export class Community extends Signable {
       numAuctions: this.numAuctions,
       numProposals: this.numProposals,
       ethFunded: this.ethFunded,
+      totalFunded: this.totalFunded,
       description: this.description,
     };
   }


### PR DESCRIPTION
- Adds `totalFunded` as community property to complement `ethFunded` as some communities use alternative currencies
- Sorts home page communities by number of proposals