### PR TITLE
Add host switcher

### DIFF
--- a/packages/prop-house-webapp/src/components/AdminTool/AdminTool.module.css
+++ b/packages/prop-house-webapp/src/components/AdminTool/AdminTool.module.css
@@ -1,7 +1,8 @@
 .displayAdminTool {
-
+  display: flex;
+  align-items: center;
 }
 
 .hideAdminTool {
-	display: none;
+  display: none;
 }

--- a/packages/prop-house-webapp/src/components/AdminTool/index.tsx
+++ b/packages/prop-house-webapp/src/components/AdminTool/index.tsx
@@ -1,21 +1,15 @@
-import clsx from "clsx";
-import { useAppSelector } from "../../hooks";
-import classes from "./AdminTool.module.css";
+import clsx from 'clsx';
+import { useAppSelector } from '../../hooks';
+import classes from './AdminTool.module.css';
 
 export interface AdminToolProps {
   children: React.ReactNode;
 }
 const AdminTool: React.FC<AdminToolProps> = (props: AdminToolProps) => {
   const { children } = props;
-  const displayAdmin = useAppSelector(
-    (state) => state.configuration.displayAdmin
-  );
+  const displayAdmin = useAppSelector(state => state.configuration.displayAdmin);
   return (
-    <div
-      className={clsx(
-        displayAdmin ? classes.displayAdminTool : classes.hideAdminTool
-      )}
-    >
+    <div className={clsx(displayAdmin ? classes.displayAdminTool : classes.hideAdminTool)}>
       {children}
     </div>
   );

--- a/packages/prop-house-webapp/src/components/DevEnvDropdown/DevEnvDropdown.module.css
+++ b/packages/prop-house-webapp/src/components/DevEnvDropdown/DevEnvDropdown.module.css
@@ -1,0 +1,3 @@
+.dropDownBtn {
+  background-color: white !important;
+}

--- a/packages/prop-house-webapp/src/components/DevEnvDropdown/index.tsx
+++ b/packages/prop-house-webapp/src/components/DevEnvDropdown/index.tsx
@@ -1,0 +1,32 @@
+import { Dropdown } from 'react-bootstrap';
+import { useNavigate } from 'react-router-dom';
+import { BackendHost } from '../../state/slices/configuration';
+import clsx from 'clsx';
+import classes from './DevEnvDropdown.module.css';
+
+const DevEnvDropDown = () => {
+  const navigate = useNavigate();
+
+  const handleClick = (env: BackendHost) => {
+    localStorage.setItem('devEnv', env.toString());
+    navigate(0);
+  };
+
+  return (
+    <div className={clsx(classes.dropdown, 'houseDropdown')}>
+      <Dropdown>
+        <Dropdown.Toggle variant="success" id="dropdown-basic" className={classes.dropDownBtn}>
+          ENV
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu>
+          <Dropdown.Item onClick={() => handleClick(BackendHost.Local)}>local</Dropdown.Item>
+          <Dropdown.Item onClick={() => handleClick(BackendHost.Dev)}>dev</Dropdown.Item>
+          <Dropdown.Item onClick={() => handleClick(BackendHost.Prod)}>prod</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
+  );
+};
+
+export default DevEnvDropDown;

--- a/packages/prop-house-webapp/src/components/DevEnvDropdown/index.tsx
+++ b/packages/prop-house-webapp/src/components/DevEnvDropdown/index.tsx
@@ -20,7 +20,9 @@ const DevEnvDropDown = () => {
         </Dropdown.Toggle>
 
         <Dropdown.Menu>
-          <Dropdown.Item onClick={() => handleClick(BackendHost.Local)}>local</Dropdown.Item>
+          {process.env.REACT_APP_NODE_ENV === BackendHost.Local && (
+            <Dropdown.Item onClick={() => handleClick(BackendHost.Local)}>local</Dropdown.Item>
+          )}
           <Dropdown.Item onClick={() => handleClick(BackendHost.Dev)}>dev</Dropdown.Item>
           <Dropdown.Item onClick={() => handleClick(BackendHost.Prod)}>prod</Dropdown.Item>
         </Dropdown.Menu>

--- a/packages/prop-house-webapp/src/components/NavBar/index.tsx
+++ b/packages/prop-house-webapp/src/components/NavBar/index.tsx
@@ -6,6 +6,8 @@ import clsx from 'clsx';
 import LocaleSwitcher from '../LocaleSwitcher';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
+import AdminTool from '../AdminTool';
+import DevEnvDropDown from '../DevEnvDropdown';
 
 const NavBar = () => {
   const { t } = useTranslation();
@@ -41,6 +43,10 @@ const NavBar = () => {
               <Nav.Link as="div">
                 <Web3ModalButton classNames={classes.link} />
               </Nav.Link>
+
+              <AdminTool>
+                <DevEnvDropDown />
+              </AdminTool>
             </div>
           </Nav>
         </Navbar.Collapse>

--- a/packages/prop-house-webapp/src/state/slices/configuration.ts
+++ b/packages/prop-house-webapp/src/state/slices/configuration.ts
@@ -6,14 +6,40 @@ export interface ConfigurationSlice {
   displayAdmin: boolean;
 }
 
+export enum BackendHost {
+  Local = 'local',
+  Dev = 'development',
+  Prod = 'production',
+}
+
+const backendHostURI = (b: BackendHost) => {
+  const localhost = 'http://localhost:3000';
+  switch (b) {
+    case BackendHost.Local:
+      return localhost;
+    case BackendHost.Dev:
+      return process.env.REACT_APP_DEV_BACKEND_URI
+        ? process.env.REACT_APP_DEV_BACKEND_URI
+        : localhost;
+    case BackendHost.Prod:
+      return process.env.REACT_APP_PROD_BACKEND_URI
+        ? process.env.REACT_APP_PROD_BACKEND_URI
+        : localhost;
+  }
+};
+
+const envToUri = (env: BackendHost | undefined) => {
+  const devEnv = localStorage.getItem('devEnv');
+
+  if (!env && devEnv) return backendHostURI(devEnv as BackendHost); // localhost && dev set env
+  if (!env) return backendHostURI(BackendHost.Local); // localhost
+
+  return backendHostURI(env as BackendHost); // development | prod environments
+};
+
 const initialState: ConfigurationSlice = {
   etherscanHost: 'https://etherscan.io',
-  backendHost:
-    process.env.REACT_APP_NODE_ENV === 'production' && process.env.REACT_APP_PROD_BACKEND_URI
-      ? process.env.REACT_APP_PROD_BACKEND_URI
-      : process.env.REACT_APP_NODE_ENV === 'development' && process.env.REACT_APP_DEV_BACKEND_URI
-      ? process.env.REACT_APP_DEV_BACKEND_URI
-      : 'http://localhost:3000',
+  backendHost: envToUri(process.env.REACT_APP_NODE_ENV as BackendHost),
   displayAdmin: process.env.REACT_APP_NODE_ENV === 'production' ? false : true,
 };
 

--- a/packages/prop-house-webapp/src/state/slices/configuration.ts
+++ b/packages/prop-house-webapp/src/state/slices/configuration.ts
@@ -40,7 +40,9 @@ const envToUri = (env: BackendHost | undefined) => {
 const initialState: ConfigurationSlice = {
   etherscanHost: 'https://etherscan.io',
   backendHost: envToUri(process.env.REACT_APP_NODE_ENV as BackendHost),
-  displayAdmin: process.env.REACT_APP_NODE_ENV === 'production' ? false : true,
+  displayAdmin:
+    process.env.REACT_APP_NODE_ENV !== BackendHost.Prod &&
+    process.env.REACT_APP_NODE_ENV !== BackendHost.Dev,
 };
 
 export const configSlice = createSlice({

--- a/packages/prop-house-webapp/src/state/slices/configuration.ts
+++ b/packages/prop-house-webapp/src/state/slices/configuration.ts
@@ -31,7 +31,7 @@ const backendHostURI = (b: BackendHost) => {
 const envToUri = (env: BackendHost | undefined) => {
   const devEnv = localStorage.getItem('devEnv');
 
-  if (!env && devEnv) return backendHostURI(devEnv as BackendHost); // localhost && dev set env
+  if ((!env || env === BackendHost.Dev) && devEnv) return backendHostURI(devEnv as BackendHost); // localhost && dev set env
   if (!env) return backendHostURI(BackendHost.Local); // localhost
 
   return backendHostURI(env as BackendHost); // development | prod environments
@@ -40,9 +40,7 @@ const envToUri = (env: BackendHost | undefined) => {
 const initialState: ConfigurationSlice = {
   etherscanHost: 'https://etherscan.io',
   backendHost: envToUri(process.env.REACT_APP_NODE_ENV as BackendHost),
-  displayAdmin:
-    process.env.REACT_APP_NODE_ENV !== BackendHost.Prod &&
-    process.env.REACT_APP_NODE_ENV !== BackendHost.Dev,
+  displayAdmin: process.env.REACT_APP_NODE_ENV !== BackendHost.Prod,
 };
 
 export const configSlice = createSlice({


### PR DESCRIPTION
- Adds dropdown to switch between different backend hosts for easier development. 
- Shows diff options depending on env (localhost, dev and prod on local / dev & prod on previews)
- Does not display switcher on prod