### PR TITLE
Don't show crown if prop has zero votes

### DIFF
--- a/packages/prop-house-webapp/src/utils/getWinningIds.ts
+++ b/packages/prop-house-webapp/src/utils/getWinningIds.ts
@@ -20,7 +20,13 @@ const getWinningIds = (
   const sortedProposals = proposals && sortByVotesAndHandleTies(proposals.slice(), false);
 
   // push the winning ids to the array
-  sortedProposals && sortedProposals.slice(0, auction.numWinners).map(p => winningIds.push(p.id));
+  sortedProposals &&
+    sortedProposals.slice(0, auction.numWinners).map(p =>
+      auctionStatus(auction) === AuctionStatus.AuctionVoting
+        ? // skip proposals with 0 votes if auction is in voting phase
+          Number(p.voteCount) !== 0 && winningIds.push(p.id)
+        : winningIds.push(p.id),
+    );
 
   return winningIds;
 };


### PR DESCRIPTION
When a round enters the voting stage technically there are "winners" tied for first place (ie earliest submitted x-number of props). We shouldn't show a crown if the prop has zero votes.

Below you can see that even though we will have 5 winners, we won't show a crown until a prop has at least 1 vote.
<img width="726" alt="Screenshot 2023-01-27 at 3 34 13 PM" src="https://user-images.githubusercontent.com/26611339/215191754-b7abd0db-3cb7-45bd-86de-eb8780e4fdb2.png">
