### PR TITLE
Fix cardrender route to alleviate errors

### DIFF
--- a/packages/prop-house-card-renderer/README.md
+++ b/packages/prop-house-card-renderer/README.md
@@ -21,6 +21,6 @@ mkdir cache
 CACHE_PATH=cache yarn start:dev
 ```
 
-Once the script is running you can edit the HTML block in [index.ts](src/index.ts) which uses normal JavaScript string interpolation. Pointing your browser at `http://localhost:3002/:proposalId` will render the card using the local HTML.
+Once the script is running you can edit the HTML block in [index.ts](src/index.ts) which uses normal JavaScript string interpolation. Pointing your browser at `http://localhost:3002/local/:proposalId` will render the card using the local HTML.
 
 Alternatively, calling `http://localhost:3000/remote/:path` will just render a PNG of the frontend at `https://prop.house/:path/card` if frontend devs would prefer to use React and keep the card within the main codebase. The `:path` property can be multiple levels as well, meaning `http://localhost:3002/remote/proposal/99` will fetch `https://prop.house/proposal/99/card`.

--- a/packages/prop-house-card-renderer/src/index.ts
+++ b/packages/prop-house-card-renderer/src/index.ts
@@ -83,15 +83,20 @@ const generateRemote =
       userAgent: 'PropHouseSnapshotBot',
     });
     console.log(remoteCardUrl(path));
-    await page.goto(remoteCardUrl(path), {
-      waitUntil: config.remoteWaitUntil,
-    });
-    await page.screenshot({ path: cacheFilePath });
+    try {
+      await page.goto(remoteCardUrl(path), {
+        waitUntil: config.remoteWaitUntil,
+      });
+      await page.screenshot({ path: cacheFilePath });
 
-    res
-      .header('X-PropHouse-Type', 'local')
-      .header('Content-Type', 'image/png')
-      .send(fs.readFileSync(cacheFilePath));
+      res
+        .header('X-PropHouse-Type', 'local')
+        .header('Content-Type', 'image/png')
+        .send(fs.readFileSync(cacheFilePath));
+    } catch (e) {
+      console.error(e);
+      res.status(500).send({ message: 'Unable to render cards at this time' });
+    }
   };
 
 (async () => {

--- a/packages/prop-house-card-renderer/src/index.ts
+++ b/packages/prop-house-card-renderer/src/index.ts
@@ -103,7 +103,6 @@ const generateRemote =
   });
 
   app.get('/remote/*', generateRemote(browser));
-  app.get('/:propId', generateLocal);
   app.get('/:propId/local', generateLocal);
 
   app.listen(config.port, () => {

--- a/packages/prop-house-card-renderer/src/index.ts
+++ b/packages/prop-house-card-renderer/src/index.ts
@@ -1,111 +1,112 @@
-import express from 'express'
-import puppeteer, { PuppeteerLifeCycleEvent } from 'puppeteer';
-import fs from 'fs'
+import express from 'express';
+import puppeteer, { Browser, PuppeteerLifeCycleEvent } from 'puppeteer';
+import fs from 'fs';
 import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
 
 type Config = {
-    port: number,
-    webAppBase: string,
-    apiBase: string,
-    cachePath: string,
-    cardHeight: number,
-    cardWidth: number,
-    remoteWaitUntil: PuppeteerLifeCycleEvent
-}
+  port: number;
+  webAppBase: string;
+  apiBase: string;
+  cachePath: string;
+  cardHeight: number;
+  cardWidth: number;
+  remoteWaitUntil: PuppeteerLifeCycleEvent;
+};
 
 const config: Config = {
-    port: process.env.PORT ? Number(process.env.PORT) : 3002,
-    webAppBase: process.env.WEB_APP_BASE ?? "https://prop.house",
-    apiBase: process.env.ABI_BASE ?? "https://prod.backend.prop.house",
-    cachePath: process.env.CACHE_PATH ?? "/tmp/phcache",
-    cardHeight: process.env.CARD_HEIGHT ? Number(process.env.CARD_HEIGHT) : 512,
-    cardWidth: process.env.CARD_WIDTH ? Number(process.env.CARD_WIDTH) : 1024,
-    remoteWaitUntil: process.env.REMOTE_WAIT_UNTIL as PuppeteerLifeCycleEvent ?? "networkidle0"
-}
+  port: process.env.PORT ? Number(process.env.PORT) : 3002,
+  webAppBase: process.env.WEB_APP_BASE ?? 'https://prop.house',
+  apiBase: process.env.ABI_BASE ?? 'https://prod.backend.prop.house',
+  cachePath: process.env.CACHE_PATH ?? '/tmp/phcache',
+  cardHeight: process.env.CARD_HEIGHT ? Number(process.env.CARD_HEIGHT) : 512,
+  cardWidth: process.env.CARD_WIDTH ? Number(process.env.CARD_WIDTH) : 1024,
+  remoteWaitUntil: (process.env.REMOTE_WAIT_UNTIL as PuppeteerLifeCycleEvent) ?? 'networkidle0',
+};
 
-const wrapper = new PropHouseWrapper(config.apiBase)
+const wrapper = new PropHouseWrapper(config.apiBase);
 
 /**
  * Generate raw HTML to be rendered for the Prop House Card locally using the Prop
  * House wrapper library. Edit this to change the `/:id/local` card.
  */
 const localHtml = async (propId: string) => {
-    const proposal = await wrapper.getProposal(Number(propId));
+  const proposal = await wrapper.getProposal(Number(propId));
 
-    return `
+  return `
 <html>
 <h1>${proposal.title}</h1>
 <p>${proposal.tldr}</p>
 </html>
-`
-}
+`;
+};
 
-const remoteCardUrl = (path: string) => [config.webAppBase, path, "card"].join('/')
+const remoteCardUrl = (path: string) => [config.webAppBase, path, 'card'].join('/');
 
-const cachePath = (propId: string) => [config.cachePath, [propId.replace(/\.\//g, "").replace(/\//g, "_"), "png"].join('.')].join("/")
+const cachePath = (propId: string) =>
+  [config.cachePath, [propId.replace(/\.\//g, '').replace(/\//g, '_'), 'png'].join('.')].join('/');
 
 const generateLocal = async (req: express.Request<{ propId: string }>, res: express.Response) => {
-    const { propId } = req.params;
-    const html = await localHtml(propId);
-    const path = cachePath(propId)
+  const { propId } = req.params;
+  const html = await localHtml(propId);
+  const path = cachePath(propId);
 
-    const browser = await puppeteer.launch();
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  page.emulate({
+    viewport: {
+      width: config.cardWidth,
+      height: config.cardHeight,
+    },
+    userAgent: 'PropHouseSnapshotBot',
+  });
+  await page.setContent(html);
+  await page.screenshot({ path });
+
+  await browser.close();
+  res
+    .header('X-PropHouse-Type', 'local')
+    .header('Content-Type', 'image/png')
+    .send(fs.readFileSync(path));
+};
+
+const generateRemote =
+  (browser: Browser) => async (req: express.Request, res: express.Response) => {
+    const path = req.params[0];
+    const cacheFilePath = cachePath(path);
+
     const page = await browser.newPage();
     page.emulate({
-        viewport: {
-            width: config.cardWidth,
-            height: config.cardHeight
-        },
-        userAgent: "PropHouseSnapshotBot"
-    })
-    await page.setContent(html)
-    await page.screenshot({ path });
-
-    await browser.close();
-    res.header("X-PropHouse-Type", "local")
-        .header("Content-Type", "image/png")
-        .send(fs.readFileSync(path))
-}
-
-const generateRemote = async (req: express.Request, res: express.Response) => {
-    const path = req.params[0]
-    const cacheFilePath = cachePath(path)
-
-    const browser = await puppeteer.launch();
-    const page = await browser.newPage();
-    page.emulate({
-        viewport: {
-            width: config.cardWidth,
-            height: config.cardHeight
-        },
-        userAgent: "PropHouseSnapshotBot"
-    })
-    console.log(remoteCardUrl(path))
+      viewport: {
+        width: config.cardWidth,
+        height: config.cardHeight,
+      },
+      userAgent: 'PropHouseSnapshotBot',
+    });
+    console.log(remoteCardUrl(path));
     await page.goto(remoteCardUrl(path), {
-        waitUntil: config.remoteWaitUntil
-    })
+      waitUntil: config.remoteWaitUntil,
+    });
     await page.screenshot({ path: cacheFilePath });
 
-    await browser.close();
-    res.header("X-PropHouse-Type", "local")
-        .header("Content-Type", "image/png")
-        .send(fs.readFileSync(cacheFilePath))
-}
+    res
+      .header('X-PropHouse-Type', 'local')
+      .header('Content-Type', 'image/png')
+      .send(fs.readFileSync(cacheFilePath));
+  };
 
 (async () => {
-    const app = express();
+  const browser = await puppeteer.launch();
+  const app = express();
 
-    app.get('/', (req, res) => {
-        res.send("Welcome to Prop House card renderer")
-    })
+  app.get('/', (req, res) => {
+    res.send('Welcome to Prop House card renderer');
+  });
 
-    app.get('/:propId', generateLocal)
-    app.get('/remote/*', generateRemote)
-    app.get('/:propId/local', generateLocal)
+  app.get('/remote/*', generateRemote(browser));
+  app.get('/:propId', generateLocal);
+  app.get('/:propId/local', generateLocal);
 
-
-    app.listen(config.port, () => {
-        console.log(`Listening on ${config.port}`)
-    })
-
-})()
+  app.listen(config.port, () => {
+    console.log(`Listening on ${config.port}`);
+  });
+})();


### PR DESCRIPTION
Previous implementation had the base route that would be triggered upon every call, even to remote renders. This would cause errors and the application to restart.

By moving the route down, the remote route will match first and performance should improve.

This PR also refactors the browser object so it is created less frequently for remote renders.