### PR TITLE
Add available image to Prop share card

### DIFF
--- a/packages/prop-house-webapp/src/components/OpenGraphProposalCard/OpenGraphProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/OpenGraphProposalCard/OpenGraphProposalCard.module.css
@@ -48,10 +48,34 @@
   line-height: 150%;
   color: var(--brand-gray);
 }
-
 .openGraphAvatar {
   font-weight: 700;
   font-size: 42px;
   line-height: 70%;
   color: #14161b;
+}
+.infoAndImage {
+  display: flex;
+  gap: 15px;
+  justify-content: space-between;
+  align-items: center;
+  min-height: 11rem;
+  margin-top: 10px;
+}
+.propImgContainer {
+  min-width: 11rem !important;
+  width: 11rem;
+  height: 11rem;
+  border-radius: 24px;
+  outline: 1px solid var(--border-light);
+  min-width: min-content;
+  overflow: hidden;
+  background: white;
+}
+.propImgContainer img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  min-height: 120px;
+  min-width: 120px;
 }

--- a/packages/prop-house-webapp/src/components/OpenGraphProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/OpenGraphProposalCard/index.tsx
@@ -10,6 +10,7 @@ import { useAppSelector } from '../../hooks';
 import classes from './OpenGraphProposalCard.module.css';
 import trimEthAddress from '../../utils/trimEthAddress';
 import { InfuraProvider } from '@ethersproject/providers';
+import getImageFromDescription from '../../utils/getImageFromDescription';
 
 const OpenGraphProposalCard: React.FC = () => {
   const params = useParams();
@@ -19,6 +20,7 @@ const OpenGraphProposalCard: React.FC = () => {
   const [round, setRound] = useState<Auction>();
   const [community, setCommunity] = useState<Community>();
   const [ens, setEns] = useState<null | string>(null);
+  const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
 
   const backendHost = useAppSelector(state => state.configuration.backendHost);
   const client = useRef(new PropHouseWrapper(backendHost));
@@ -54,6 +56,14 @@ const OpenGraphProposalCard: React.FC = () => {
     fetch();
   }, [id]);
 
+  useEffect(() => {
+    if (proposal) {
+      const getImg = async () => setImageUrl(await getImageFromDescription(proposal));
+
+      getImg();
+    }
+  }, [proposal]);
+
   return (
     <>
       {community && round && proposal && (
@@ -67,12 +77,20 @@ const OpenGraphProposalCard: React.FC = () => {
             <div className={classes.propName}>{proposal.title}</div>
           </span>
 
-          <div className={classes.userInfo}>
-            <span className={classes.proposedBy}>Proposed by</span>
-            <div className={classes.openGraphAvatar}>
-              {ens ? ens : trimEthAddress(proposal.address)}
+          <span className={classes.infoAndImage}>
+            <div className={classes.userInfo}>
+              <span className={classes.proposedBy}>Proposed by</span>
+              <div className={classes.openGraphAvatar}>
+                {ens ? ens : trimEthAddress(proposal.address)}
+              </div>
             </div>
-          </div>
+
+            {imageUrl && (
+              <div className={classes.propImgContainer}>
+                <img src={imageUrl} alt="propImage" />
+              </div>
+            )}
+          </span>
         </div>
       )}
     </>

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -96,7 +96,7 @@ const ProposalCard: React.FC<{
               </div>
             </div>
 
-            {imageUrl && imageUrl && (
+            {imageUrl && (
               <div className={classes.propImgContainer}>
                 <img src={imageUrl} alt="propCardImage" />
               </div>


### PR DESCRIPTION
Add image to proposal share card if there's one in the proposal itself

## Example 1
<img width="700" alt="Screenshot 2023-01-30 at 9 57 52 AM" src="https://user-images.githubusercontent.com/26611339/215512199-c64aaf70-65ba-4c40-9562-1fa70acc06a3.png">

## Example 2
<img width="700" alt="Screenshot 2023-01-30 at 9 59 23 AM" src="https://user-images.githubusercontent.com/26611339/215512579-32bc638f-449d-4583-b971-b8f03e4cb53d.png">

## Example with no image
<img width="700" alt="Screenshot 2023-01-30 at 9 59 59 AM" src="https://user-images.githubusercontent.com/26611339/215512739-e5a0f4a2-8cea-4e9f-b692-2322c6cbc62a.png">
