### PR TITLE
Fix dep issue

### DIFF
--- a/packages/prop-house-backend/src/task/tasks.module.ts
+++ b/packages/prop-house-backend/src/task/tasks.module.ts
@@ -8,14 +8,17 @@ import { ProposalsService } from 'src/proposal/proposals.service';
 import { EIP1271SignatureValidationTaskService } from './tasks';
 import { VotesService } from 'src/vote/votes.service';
 import { Vote } from 'src/vote/vote.entity';
+import { InfiniteAuctionService } from 'src/infinite-auction/infinite-auction.service';
+import { InfiniteAuction } from 'src/infinite-auction/infinite-auction.entity';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
-    TypeOrmModule.forFeature([Proposal, Vote, Auction]),
+    TypeOrmModule.forFeature([Proposal, Vote, Auction, InfiniteAuction]),
   ],
   providers: [
     ProposalsService,
+    InfiniteAuctionService,
     VotesService,
     AuctionsService,
     EIP1271SignatureValidationTaskService,


### PR DESCRIPTION
When running `crt-infinite`, I ran into the following error: 

```
ERROR [ExceptionHandler] Nest can't resolve dependencies of the ProposalsService (ProposalRepository, ?). Please make sure that the argument InfiniteAuctionService at index [1] is available in the TasksModule context.

Potential solutions:
- If InfiniteAuctionService is a provider, is it part of the current TasksModule?
- If InfiniteAuctionService is exported from a separate @Module, is that module imported within TasksModule?
  @Module({
    imports: [ /* the Module containing InfiniteAuctionService */ ]
  })
```

This PR fixes above by importing reqs into `tasks.module.ts`