### PR TITLE
Add loaders on House & Round pages 

### DIFF
--- a/packages/prop-house-webapp/src/components/NotFound/NotFound.module.css
+++ b/packages/prop-house-webapp/src/components/NotFound/NotFound.module.css
@@ -3,6 +3,7 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-evenly;
+  width: 100%;
 }
 .invalidAddressCard img {
   width: auto;

--- a/packages/prop-house-webapp/src/pages/House/index.tsx
+++ b/packages/prop-house-webapp/src/pages/House/index.tsx
@@ -39,7 +39,8 @@ const House = () => {
   const [roundsOnDisplay, setRoundsOnDisplay] = useState<StoredAuction[]>([]);
   const [currentRoundStatus, setCurrentRoundStatus] = useState<number>(RoundStatus.AllRounds);
   const [input, setInput] = useState<string>('');
-  const [isLoading, setIsLoading] = useState(false);
+  const [loadingCommunity, setLoadingCommunity] = useState(false);
+  const [loadingRounds, setLoadingRounds] = useState(false);
   const { t } = useTranslation();
 
   const [numberOfRoundsPerStatus, setNumberOfRoundsPerStatus] = useState<number[]>([]);
@@ -51,10 +52,10 @@ const House = () => {
   // fetch community
   useEffect(() => {
     const fetchCommunity = async () => {
-      setIsLoading(true);
+      setLoadingCommunity(true);
       const community = await client.current.getCommunityWithName(slugToName(slug));
       dispatch(setActiveCommunity(community));
-      setIsLoading(false);
+      setLoadingCommunity(false);
     };
     fetchCommunity();
   }, [slug, dispatch]);
@@ -62,7 +63,7 @@ const House = () => {
   // fetch rounds
   useEffect(() => {
     if (!community) return;
-
+    setLoadingRounds(true);
     const fetchRounds = async () => {
       const rounds = await client.current.getAuctionsForCommunity(community.id);
       setRounds(rounds);
@@ -84,6 +85,7 @@ const House = () => {
           auctionStatus(r) === AuctionStatus.AuctionAcceptingProps ||
           auctionStatus(r) === AuctionStatus.AuctionVoting,
       ).length === 0 && setCurrentRoundStatus(RoundStatus.AllRounds);
+      setLoadingRounds(false);
     };
     fetchRounds();
   }, [community]);
@@ -128,7 +130,7 @@ const House = () => {
         />
       )}
 
-      {isLoading ? (
+      {loadingCommunity ? (
         <LoadingIndicator />
       ) : !community ? (
         <NotFound />
@@ -153,22 +155,20 @@ const House = () => {
           <div className={classes.houseContainer}>
             <Container>
               <Row>
-                {roundsOnDisplay ? (
-                  roundsOnDisplay.length > 0 ? (
-                    sortRoundByStatus(roundsOnDisplay).map((round, index) => (
-                      <Col key={index} xl={6}>
-                        <RoundCard round={round} />
-                      </Col>
-                    ))
-                  ) : input === '' ? (
-                    <Col>
-                      <ErrorMessageCard message={t('noRoundsAvailable')} />
-                    </Col>
-                  ) : (
-                    <NoSearchResults />
-                  )
-                ) : (
+                {loadingRounds ? (
                   <LoadingIndicator />
+                ) : roundsOnDisplay.length > 0 ? (
+                  sortRoundByStatus(roundsOnDisplay).map((round, index) => (
+                    <Col key={index} xl={6}>
+                      <RoundCard round={round} />
+                    </Col>
+                  ))
+                ) : input === '' ? (
+                  <Col>
+                    <ErrorMessageCard message={t('noRoundsAvailable')} />
+                  </Col>
+                ) : (
+                  <NoSearchResults />
                 )}
               </Row>
             </Container>

--- a/packages/prop-house-webapp/src/pages/Round/Round.module.css
+++ b/packages/prop-house-webapp/src/pages/Round/Round.module.css
@@ -31,3 +31,6 @@
   padding-top: 12px;
   border-bottom: 1px solid var(--border-light);
 }
+.loader {
+  width: 100%;
+}

--- a/packages/prop-house-webapp/src/pages/Round/index.tsx
+++ b/packages/prop-house-webapp/src/pages/Round/index.tsx
@@ -23,6 +23,7 @@ import ReactMarkdown from 'react-markdown';
 import ProposalModal from '../../components/ProposalModal';
 import { useSigner } from 'wagmi';
 import LoadingIndicator from '../../components/LoadingIndicator';
+import NotFound from '../../components/NotFound';
 
 const Round = () => {
   const location = useLocation();
@@ -116,12 +117,14 @@ const Round = () => {
       <div className={classes.roundContainer}>
         <Container className={classes.cardsContainer}>
           <div className={classes.propCards}>
-            {!loading && round && proposals ? (
-              <RoundContent auction={round} proposals={proposals} />
-            ) : (
+            {loading ? (
               <div className={classes.loader}>
                 <LoadingIndicator />
               </div>
+            ) : !round ? (
+              <NotFound />
+            ) : (
+              proposals && <RoundContent auction={round} proposals={proposals} />
             )}
           </div>
         </Container>

--- a/packages/prop-house-webapp/src/pages/Round/index.tsx
+++ b/packages/prop-house-webapp/src/pages/Round/index.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import RoundHeader from '../../components/RoundHeader';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
 import {
   setActiveCommunity,
@@ -11,7 +11,6 @@ import {
 } from '../../state/slices/propHouse';
 import { Container } from 'react-bootstrap';
 import classes from './Round.module.css';
-import ErrorMessageCard from '../../components/ErrorMessageCard';
 import RoundUtilityBar from '../../components/RoundUtilityBar';
 import RoundContent from '../../components/RoundContent';
 import { nameToSlug, slugToName } from '../../utils/communitySlugs';
@@ -21,9 +20,9 @@ import { cardServiceUrl, CardType } from '../../utils/cardServiceUrl';
 import OpenGraphElements from '../../components/OpenGraphElements';
 import { markdownComponentToPlainText } from '../../utils/markdownToPlainText';
 import ReactMarkdown from 'react-markdown';
-import { useTranslation } from 'react-i18next';
 import ProposalModal from '../../components/ProposalModal';
 import { useSigner } from 'wagmi';
+import LoadingIndicator from '../../components/LoadingIndicator';
 
 const Round = () => {
   const location = useLocation();
@@ -38,10 +37,11 @@ const Round = () => {
   const host = useAppSelector(state => state.configuration.backendHost);
   const modalActive = useAppSelector(state => state.propHouse.modalActive);
   const client = useRef(new PropHouseWrapper(host));
-  const { t } = useTranslation();
 
   const isRoundOver = round && auctionStatus(round) === AuctionStatus.AuctionEnded;
   const isVotingWindow = round && auctionStatus(round) === AuctionStatus.AuctionVoting;
+
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     client.current = new PropHouseWrapper(host, signer);
@@ -65,6 +65,7 @@ const Round = () => {
   // fetch proposals
   useEffect(() => {
     if (!round) return;
+    setLoading(true);
 
     const fetchAuctionProposals = async () => {
       const proposals = await client.current.getAuctionProposals(round.id);
@@ -75,6 +76,8 @@ const Round = () => {
       isVotingWindow || isRoundOver
         ? dispatchSortProposals(dispatch, SortType.VoteCount, false)
         : dispatchSortProposals(dispatch, SortType.CreatedAt, false);
+
+      setLoading(false);
     };
     fetchAuctionProposals();
 
@@ -113,10 +116,12 @@ const Round = () => {
       <div className={classes.roundContainer}>
         <Container className={classes.cardsContainer}>
           <div className={classes.propCards}>
-            {round && proposals ? (
+            {!loading && round && proposals ? (
               <RoundContent auction={round} proposals={proposals} />
             ) : (
-              <ErrorMessageCard message={t('noRoundsAvailable')} />
+              <div className={classes.loader}>
+                <LoadingIndicator />
+              </div>
             )}
           </div>
         </Container>


### PR DESCRIPTION
Redid the loading logic for the House & Round pages that would cause the "No Rounds available" message to prematurely display while fetching.