### PR TITLE
Deadline dates component

### DIFF
--- a/packages/prop-house-webapp/src/components/DeadlineDates/DeadlineDates.module.css
+++ b/packages/prop-house-webapp/src/components/DeadlineDates/DeadlineDates.module.css
@@ -1,0 +1,5 @@
+.date {
+  margin: 0;
+  color: var(--brand-pink) !important;
+  font-weight: bold;
+}

--- a/packages/prop-house-webapp/src/components/DeadlineDates/index.tsx
+++ b/packages/prop-house-webapp/src/components/DeadlineDates/index.tsx
@@ -1,0 +1,29 @@
+import { StoredAuction } from '@nouns/prop-house-wrapper/dist/builders';
+import { auctionStatus, AuctionStatus } from '../../utils/auctionStatus';
+import formatTime from '../../utils/formatTime';
+import classes from './DeadlineDates.module.css';
+
+const DeadlineDates: React.FC<{ round: StoredAuction }> = props => {
+  const { round } = props;
+  const { startTime, proposalEndTime, votingEndTime } = round;
+
+  const notStarted = auctionStatus(round) === AuctionStatus.AuctionNotStarted;
+  const proposing = auctionStatus(round) === AuctionStatus.AuctionAcceptingProps;
+  const voting = auctionStatus(round) === AuctionStatus.AuctionVoting;
+
+  const proposingStarts = formatTime(startTime);
+  const proposingEnds = formatTime(proposalEndTime);
+  const votingEnds = formatTime(votingEndTime);
+
+  return (
+    <div className={classes.date}>
+      {proposing || notStarted
+        ? `${proposingStarts} - ${proposingEnds}`
+        : voting
+        ? `${proposingEnds} - ${votingEnds}`
+        : `${proposingStarts} - ${votingEnds}`}
+    </div>
+  );
+};
+
+export default DeadlineDates;

--- a/packages/prop-house-webapp/src/components/RoundHeader/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundHeader/index.tsx
@@ -11,6 +11,7 @@ import { nameToSlug } from '../../utils/communitySlugs';
 import ReadMore from '../ReadMore';
 import { ForceOpenInNewTab } from '../ForceOpenInNewTab';
 import { isLongName } from '../../utils/isLongName';
+import DeadlineDates from '../DeadlineDates';
 
 const RoundHeader: React.FC<{
   community: Community;
@@ -19,7 +20,7 @@ const RoundHeader: React.FC<{
   const { community, auction } = props;
   const navigate = useNavigate();
 
-  const roundDescription =
+  const roundDescription = (
     <>
       {/* support both markdown & html links in community's description.  */}
       <Markdown
@@ -31,7 +32,7 @@ const RoundHeader: React.FC<{
                 target: '_blank',
                 rel: 'noreferrer',
               },
-            }
+            },
           },
         }}
       >
@@ -40,7 +41,9 @@ const RoundHeader: React.FC<{
             a: ['href', 'target'],
           },
         })}
-      </Markdown></>
+      </Markdown>
+    </>
+  );
 
   return (
     <Row className={classes.profileHeaderRow}>
@@ -56,9 +59,7 @@ const RoundHeader: React.FC<{
         </div>
 
         <Col lg={12} className={classes.communityInfoCol}>
-          <div className={classes.date}>
-            {auction && `${formatTime(auction.startTime)} - ${formatTime(auction.proposalEndTime)}`}
-          </div>
+          <DeadlineDates round={auction} />
           <Col
             className={clsx(
               classes.titleRow,

--- a/packages/prop-house-webapp/src/components/RoundHeader/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundHeader/index.tsx
@@ -6,7 +6,6 @@ import sanitizeHtml from 'sanitize-html';
 import Markdown from 'markdown-to-jsx';
 import { IoArrowBackCircleOutline } from 'react-icons/io5';
 import { useNavigate } from 'react-router-dom';
-import formatTime from '../../utils/formatTime';
 import { nameToSlug } from '../../utils/communitySlugs';
 import ReadMore from '../ReadMore';
 import { ForceOpenInNewTab } from '../ForceOpenInNewTab';


### PR DESCRIPTION
## Before
these pink "Deadline Dates" were hardcoded as the proposal start time to proposal end time, but that wasn't helpful when the round was in voting or ended state.
<img width="250" alt="Screenshot 2023-02-10 at 10 11 05 AM" src="https://user-images.githubusercontent.com/26611339/218126219-62d4edfb-d505-48f0-b07e-3c2087a8f918.png">


## Now
| Round State      | Deadline Dates | Verify Link |
| ----------- | ----------- |----------- |
| Not Started      | Proposing Start Time - Proposing End Time       |https://deploy-preview-433--prop-house.netlify.app/nouns-on-the-ground/for-the-nounish-culture |
| Proposing   | Proposing Start Time - Proposing End Time        | https://deploy-preview-433--prop-house.netlify.app/ohv/proposing|
| Voting   | Proposing End Time - Voting End Time        | https://deploy-preview-433--prop-house.netlify.app/ohv/round-1|
| Ended   | Proposing Start Time - Voting End Time        |https://deploy-preview-433--prop-house.netlify.app/lil-nouns/round-9 |
