### PR TITLE
New ENS avatar component

### DIFF
--- a/packages/prop-house-webapp/package.json
+++ b/packages/prop-house-webapp/package.json
@@ -46,7 +46,6 @@
     "react-html-parser": "^2.0.2",
     "react-i18next": "^11.17.3",
     "react-icons": "^4.3.1",
-    "react-jazzicon": "^1.0.4",
     "react-loading": "^2.0.3",
     "react-markdown": "^8.0.1",
     "react-modal": "^3.15.1",

--- a/packages/prop-house-webapp/src/components/AddressAvatar/AddressAvatar.module.css
+++ b/packages/prop-house-webapp/src/components/AddressAvatar/AddressAvatar.module.css
@@ -2,6 +2,7 @@
   overflow: hidden;
   background: #fff;
   border-radius: 50%;
+  margin: 1px;
   outline: 1px solid var(--border-light) !important;
 }
 .glasses {

--- a/packages/prop-house-webapp/src/components/AddressAvatar/index.tsx
+++ b/packages/prop-house-webapp/src/components/AddressAvatar/index.tsx
@@ -18,12 +18,12 @@ const AddressAvatar: React.FC<{ address: string; size?: number }> = props => {
   const size = s + 'px';
 
   return (
-    <div className={classes.container}>
+    <div className={clsx(classes.container, 'avatar')}>
       <img
         style={{ height: size, width: size }}
         className={clsx(!avatar && classes.glasses)}
         src={avatar ? avatar : glasses}
-        alt="avatar"
+        alt=""
       />
     </div>
   );

--- a/packages/prop-house-webapp/src/components/CommunityCard/CommunityCard.module.css
+++ b/packages/prop-house-webapp/src/components/CommunityCard/CommunityCard.module.css
@@ -62,12 +62,10 @@
 }
 .container a {
   width: 100%;
-  min-width: 100%;
 }
 .container a img {
-  width: 212px;
-  height: 212px;
-  object-fit: cover;
+  width: 100%;
+  height: 100%;
 }
 
 .container:hover {

--- a/packages/prop-house-webapp/src/components/EthAddress/EthAddress.module.css
+++ b/packages/prop-house-webapp/src/components/EthAddress/EthAddress.module.css
@@ -13,13 +13,3 @@
 .ethAddress a:visited {
   color: inherit;
 }
-
-.paper {
-  min-width: 20px !important;
-}
-
-.avatar {
-  height: 24px;
-  width: 24px;
-  border-radius: 50%;
-}

--- a/packages/prop-house-webapp/src/components/EthAddress/index.tsx
+++ b/packages/prop-house-webapp/src/components/EthAddress/index.tsx
@@ -4,7 +4,7 @@ import { useAppSelector } from '../../hooks';
 import trimEthAddress from '../../utils/trimEthAddress';
 import classes from './EthAddress.module.css';
 import { useEnsName, useEnsAvatar } from 'wagmi';
-import Jazzicon, { jsNumberForAddress } from 'react-jazzicon';
+import AddressAvatar from '../AddressAvatar';
 
 const EthAddress: React.FC<{
   address: string;
@@ -23,16 +23,11 @@ const EthAddress: React.FC<{
 
   // trim address: 0x1234567890abcdef1234567890abcdef12345678 -> 0x1234...5678
   const shortAddress = trimEthAddress(address as string);
-
+  console.log('avatar', address, avatar);
   return (
     <div onClick={(e: any) => e.stopPropagation()} className={classes.ethAddress}>
       <a href={buildAddressHref(address)} target="_blank" rel="noreferrer">
-        {addAvatar &&
-          (avatar ? (
-            <img className={classes.avatar} src={avatar} alt="ens-avatar" />
-          ) : (
-            <Jazzicon diameter={20} seed={jsNumberForAddress(address)} />
-          ))}
+        {addAvatar && <AddressAvatar address={address} />}
         <span className={clsx(classes.address, className)}>{ens ? ens : shortAddress}</span>
       </a>
     </div>

--- a/packages/prop-house-webapp/src/components/EthAddress/index.tsx
+++ b/packages/prop-house-webapp/src/components/EthAddress/index.tsx
@@ -23,7 +23,7 @@ const EthAddress: React.FC<{
 
   // trim address: 0x1234567890abcdef1234567890abcdef12345678 -> 0x1234...5678
   const shortAddress = trimEthAddress(address as string);
-  console.log('avatar', address, avatar);
+
   return (
     <div onClick={(e: any) => e.stopPropagation()} className={classes.ethAddress}>
       <a href={buildAddressHref(address)} target="_blank" rel="noreferrer">

--- a/packages/prop-house-webapp/src/components/ProposalModalHeader/ProposalModalHeader.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalHeader/ProposalModalHeader.module.css
@@ -158,4 +158,7 @@ hr {
   .headerPropInfo {
     max-width: 75%;
   }
+  .submittedBy :global(.avatar) {
+    display: none;
+  }
 }


### PR DESCRIPTION
Use new `AddressAvatar />` component for ENS avatars

## Ens avatar vs. none (noggle fallback)
<img width="592" alt="Screenshot 2023-02-13 at 2 37 24 PM" src="https://user-images.githubusercontent.com/26611339/218557087-f6578e39-d44b-4e18-a890-8012dc75f42a.png">


## On ENS avatar errors
There can be a case of a user _having_ an ENS avatar configured, but the link is broken. This will _not_ return an error from the wagmi hook so it won't fallback to the noggles because it's "has" an ENS avatar. You can see i console logged that address and if there was an error with fetching it's ENS avatar.
<img width="447" alt="Screenshot 2023-02-13 at 2 34 31 PM" src="https://user-images.githubusercontent.com/26611339/218556337-4fe0db55-afb2-4a60-ad94-89e1f9b086fa.png">
