### PR TITLE
Clean up prop display on mobile

### DIFF
--- a/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
@@ -195,6 +195,13 @@
     height: auto;
     max-height: 400px;
   }
+  .titleContainer {
+    align-items: flex-start;
+  }
+  .crownNoun {
+    margin-top: 3px;
+    display: block;
+  }
 }
 .hideVoteModule {
   display: none;

--- a/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalCard/ProposalCard.module.css
@@ -184,6 +184,17 @@
     overflow: hidden;
     white-space: nowrap;
   }
+  .propInfo {
+    flex-direction: column;
+  }
+  .propTitle {
+    -webkit-line-clamp: 2;
+  }
+  .propImgContainer {
+    width: 100%;
+    height: auto;
+    max-height: 400px;
+  }
 }
 .hideVoteModule {
   display: none;

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -21,6 +21,7 @@ import { MdInfoOutline } from 'react-icons/md';
 import Divider from '../Divider';
 import getFirstImageFromProp from '../../utils/getFirstImageFromProp';
 import { useEffect, useState } from 'react';
+import { isMobile } from 'web3modal';
 
 const ProposalCard: React.FC<{
   proposal: StoredProposalWithVotes;
@@ -41,10 +42,17 @@ const ProposalCard: React.FC<{
     auctionStatus === AuctionStatus.AuctionAcceptingProps ||
     auctionStatus === AuctionStatus.AuctionVoting;
 
-  const [imageUrl, setImageUrl] = useState<string | undefined>(undefined);
+  const [imgUrlFromProp, setImgUrlFromProp] = useState<string | undefined>(undefined);
+  const [displayTldr, setDisplayTldr] = useState<boolean | undefined>();
 
   useEffect(() => {
-    const getImg = async () => setImageUrl(await getFirstImageFromProp(proposal));
+    let imgUrl;
+
+    const getImg = async () => {
+      imgUrl = await getFirstImageFromProp(proposal);
+      setImgUrlFromProp(imgUrl);
+      setDisplayTldr(!isMobile() || (isMobile() && !imgUrl));
+    };
     getImg();
   }, [proposal]);
 
@@ -83,22 +91,24 @@ const ProposalCard: React.FC<{
                   <div className={classes.propTitle}>{proposal.title}</div>
                 </div>
 
-                <ReactMarkdown
-                  className={classes.truncatedTldr}
-                  children={proposal.tldr}
-                  disallowedElements={['img', '']}
-                  components={{
-                    h1: 'p',
-                    h2: 'p',
-                    h3: 'p',
-                  }}
-                ></ReactMarkdown>
+                {displayTldr && (
+                  <ReactMarkdown
+                    className={classes.truncatedTldr}
+                    children={proposal.tldr}
+                    disallowedElements={['img', '']}
+                    components={{
+                      h1: 'p',
+                      h2: 'p',
+                      h3: 'p',
+                    }}
+                  />
+                )}
               </div>
             </div>
 
-            {imageUrl && (
+            {imgUrlFromProp && (
               <div className={classes.propImgContainer}>
-                <img src={imageUrl} alt="propCardImage" />
+                <img src={imgUrlFromProp} alt="propCardImage" />
               </div>
             )}
           </div>

--- a/packages/prop-house-webapp/src/components/ProposalModalHeader/ProposalModalHeader.module.css
+++ b/packages/prop-house-webapp/src/components/ProposalModalHeader/ProposalModalHeader.module.css
@@ -158,4 +158,10 @@ hr {
   .headerPropInfo {
     max-width: 75%;
   }
+  .propTitle {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
 }


### PR DESCRIPTION
This PR cleans up prop display on mobile:
- Displays title + image only on prop card (no more tldrs)
- Expand prop title when displaying prop modal to two lines (as opposed to current one line)