### PR TITLE
Handle loading of house & round pages

### DIFF
--- a/packages/prop-house-webapp/src/pages/House/index.tsx
+++ b/packages/prop-house-webapp/src/pages/House/index.tsx
@@ -23,6 +23,7 @@ import ReactMarkdown from 'react-markdown';
 import { markdownComponentToPlainText } from '../../utils/markdownToPlainText';
 import { useTranslation } from 'react-i18next';
 import { useSigner } from 'wagmi';
+import { isMobile } from 'web3modal';
 
 const House = () => {
   const location = useLocation();
@@ -146,7 +147,7 @@ const House = () => {
       )}
 
       {loadingCommunity ? (
-        <LoadingIndicator />
+        <LoadingIndicator height={isMobile() ? 288 : 349} />
       ) : !loadingCommunity && failedLoadingCommunity ? (
         <NotFound />
       ) : (

--- a/packages/prop-house-webapp/src/pages/Round/index.tsx
+++ b/packages/prop-house-webapp/src/pages/Round/index.tsx
@@ -24,6 +24,7 @@ import ProposalModal from '../../components/ProposalModal';
 import { useSigner } from 'wagmi';
 import LoadingIndicator from '../../components/LoadingIndicator';
 import NotFound from '../../components/NotFound';
+import { isMobile } from 'web3modal';
 
 const Round = () => {
   const location = useLocation();
@@ -124,7 +125,7 @@ const Round = () => {
       )}
 
       {loadingCommAndRound ? (
-        <LoadingIndicator />
+        <LoadingIndicator height={isMobile() ? 416 : 332} />
       ) : !loadingCommAndRound && commAndRoundfailedFetch ? (
         <NotFound />
       ) : (


### PR DESCRIPTION
Current loading states display "not found" blip and fail to catch potential fetch errors. This PR:
- Better handles loading states to follow each piece of data that the page is waiting on (eg header data or body data)
- Fills in corresponding components with `<LoadingIndicator/>` sized to fill in appropriate space.