### PR TITLE
Fix back btn

### DIFF
--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/RenderedProposalFields.module.css
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/RenderedProposalFields.module.css
@@ -51,6 +51,9 @@ hr {
   font-size: 1rem;
   gap: 5px;
 }
+.submittedBy a {
+  text-decoration: none !important;
+}
 
 .textSpacer {
   padding: 0px 5px;
@@ -65,16 +68,11 @@ hr {
   height: auto;
 }
 
-.communityAndPropNumber {
+.propBy {
   display: flex;
   align-items: center;
   color: var(--brand-gray) !important;
   gap: 5px;
-}
-
-.communityProfImgContainer {
-  display: flex;
-  align-items: center;
 }
 
 .communityProfImg {

--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
@@ -3,8 +3,6 @@ import { Row, Col } from 'react-bootstrap';
 import { ProposalFields } from '../../utils/proposalFields';
 import EthAddress from '../EthAddress';
 import ReactMarkdown from 'react-markdown';
-import { Link } from 'react-router-dom';
-import { nameToSlug } from '../../utils/communitySlugs';
 import Markdown from 'markdown-to-jsx';
 import sanitizeHtml from 'sanitize-html';
 import { useTranslation } from 'react-i18next';
@@ -19,7 +17,7 @@ export interface RenderedProposalProps {
 }
 
 const RenderedProposalFields: React.FC<RenderedProposalProps> = props => {
-  const { fields, address, proposalId, backButton, community, roundName } = props;
+  const { fields, address, proposalId, backButton } = props;
   const { t } = useTranslation();
 
   return (
@@ -27,27 +25,12 @@ const RenderedProposalFields: React.FC<RenderedProposalProps> = props => {
       <Row>
         <Col xl={12} className="proposalCopy">
           <div className={classes.headerContainer}>
-            <div className={classes.backBtnContainer}>
-              {backButton && backButton}
-
-              {community && roundName && (
-                <Link
-                  to={`/${nameToSlug(community.name)}`}
-                  className={classes.communityProfImgContainer}
-                >
-                  {community.name.charAt(0).toUpperCase() + community.name.slice(1)} {t('house')}:{' '}
-                  {roundName}
-                </Link>
-              )}
-            </div>
-
+            <div className={classes.backBtnContainer}>{backButton && backButton}</div>
             <div>
               {address && proposalId && (
                 <div className={classes.subinfo}>
-                  <div className={classes.communityAndPropNumber}>
-                    <span className={classes.propNumber}>
-                      {t('propCap')} #{proposalId}{' '}
-                    </span>
+                  <div className={classes.propBy}>
+                    <span>{t('propCap')}</span>
                     {t('by')}
                     <div className={classes.submittedBy}>
                       <EthAddress address={address} className={classes.submittedBy} />

--- a/packages/prop-house-webapp/src/pages/Proposal/Proposal.module.css
+++ b/packages/prop-house-webapp/src/pages/Proposal/Proposal.module.css
@@ -6,7 +6,7 @@
   align-items: center;
   width: max-content;
   align-items: center;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 .backToAuction:hover {

--- a/packages/prop-house-webapp/src/pages/Proposal/index.tsx
+++ b/packages/prop-house-webapp/src/pages/Proposal/index.tsx
@@ -107,7 +107,7 @@ const Proposal = () => {
               roundName={round && round?.title}
               backButton={
                 <div className={classes.backToAuction} onClick={() => handleBackClick()}>
-                  <IoArrowBackCircleOutline size={'1.5rem'} />
+                  <IoArrowBackCircleOutline size={'1.5rem'} /> View round
                 </div>
               }
             />


### PR DESCRIPTION
When landing directly onto a prop page, the back button was linking to the proposal's house, not the round. This PR correct the back button link to direct the user to the round and makes a few modifications on how it is displayed.

Before
![image](https://user-images.githubusercontent.com/85328329/219905122-dcc02731-d520-4ab7-98b2-0f064f5bb1b6.jpeg)

After
![image](https://user-images.githubusercontent.com/85328329/219905123-1bc503ae-0823-46b5-a598-fc0a4102a891.jpeg)