### PR TITLE
Switch rug radio to balanceOfErc20

### DIFF
--- a/packages/prop-house-communities/src/communities/index.ts
+++ b/packages/prop-house-communities/src/communities/index.ts
@@ -90,7 +90,7 @@ export const communities = new CaseInsensitiveMap(
     // Chaos
     '0xc16923543829f002E4A3f37e3E2e7CC9B8a87b96': balanceOfErc20(18),
     // Rug Radio
-    '0x6235CAEea7C515DaC14060Ec23a760090655F21b': perWalletVoteErc20(18, 5),
+    '0x6235CAEea7C515DaC14060Ec23a760090655F21b': balanceOfErc20(18, 5),
     // Noggle DAO
     '0x567C3CC159b694F4A4ed6545A86EB4fd5c5169FD': balanceOfErc721(),
     // Headline


### PR DESCRIPTION
Previously rug radio had a fixed balance of 5 votes per address over a token threshold with the `perWalletVoteErc20` strategy. This switches it to use the token balance time multiple strategy.