### PR TITLE
Display appropriate token name

### DIFF
--- a/packages/prop-house-webapp/src/components/RoundModules/index.tsx
+++ b/packages/prop-house-webapp/src/components/RoundModules/index.tsx
@@ -103,9 +103,7 @@ const RoundModules: React.FC<{
           )}
 
           {/* VOTING WINDOW */}
-          {isVotingWindow && (
-            <VotingModule communityName={community.name} totalVotes={getVoteTotal()} />
-          )}
+          {isVotingWindow && <VotingModule totalVotes={getVoteTotal()} />}
 
           {/* ROUND ENDED */}
           {isRoundOver && (

--- a/packages/prop-house-webapp/src/components/VotingModule/VotingModule.module.css
+++ b/packages/prop-house-webapp/src/components/VotingModule/VotingModule.module.css
@@ -21,6 +21,9 @@
   font-size: 14px;
   color: var(--brand-gray);
 }
+.subtitle b div {
+  display: inline;
+}
 .icon {
   width: 44px;
   height: 44px;


### PR DESCRIPTION
Problem: 
We were using house name as the token name required to vote. Some houses have differing names to their tokens (eg Nouns short shorts using Nouns token).

Solution:
Displays corresponding token name using the `community.contractAddress`, defaults to trimmed address if no name is found. 

<img width="213" alt="Screen Shot 2023-03-15 at 10 54 46 AM" src="https://user-images.githubusercontent.com/85328329/225348642-a7827502-a6a0-4929-9f8d-335c3afba57e.png">
