### PR TITLE
Fix query

### DIFF
--- a/packages/prop-house-backend/src/auction/auctions.service.ts
+++ b/packages/prop-house-backend/src/auction/auctions.service.ts
@@ -32,7 +32,7 @@ export class AuctionsService {
         .select('a.*')
         .where('a.community.id = :id', { id })
         // This select adds a new property, reflected in AuctionWithProposalCount
-        .addSelect('COUNT(p.*)', 'numProposals')
+        .addSelect('SUM(p."numProposals")', 'numProposals')
         .leftJoin(proposalCountSubquery, 'p', 'p."auctionId" = a.id')
         .groupBy('a.id')
         .getRawMany()

--- a/packages/prop-house-backend/src/infinite-auction/infinite-auction.service.ts
+++ b/packages/prop-house-backend/src/infinite-auction/infinite-auction.service.ts
@@ -37,7 +37,7 @@ export class InfiniteAuctionService {
         .select('a.*')
         .where('a.community.id = :id', { id })
         // This select adds a new property, reflected in AuctionWithProposalCount
-        .addSelect('COUNT(p.*)', 'numProposals')
+        .addSelect('SUM(p."numProposals")', 'numProposals')
         .leftJoin(proposalCountSubquery, 'p', 'p."auctionId" = a.id')
         .groupBy('a.id')
         .getRawMany()


### PR DESCRIPTION
This query was returning `1` for `numProposals` and so all round cards were displaying "1" proposal regardless of how many props they may have.