### PR TITLE
Switch to Cloudflare IPFS

### DIFF
--- a/packages/prop-house-webapp/src/components/ProposalContent/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalContent/index.tsx
@@ -52,7 +52,9 @@ const ProposalContent: React.FC<ProposalContentProps> = props => {
                 pre: ['language-*', 'lang-*'],
               },
               // edge case: handle ampersands in img links encoded from sanitization
-            }).replaceAll('&amp;', '&')}
+            })
+              .replaceAll('&amp;', '&')
+              .replace(/prophouse.mypinata.cloud/g, 'cloudflare-ipfs.com')}
           </Markdown>
         </span>
       </div>

--- a/packages/prop-house-webapp/src/utils/buildIpfsPath.ts
+++ b/packages/prop-house-webapp/src/utils/buildIpfsPath.ts
@@ -1,3 +1,3 @@
-const buildIpfsPath = (ipfsHash: string) => `https://prophouse.mypinata.cloud/ipfs/${ipfsHash}`;
+const buildIpfsPath = (ipfsHash: string) => `https://cloudflare-ipfs.com/ipfs/${ipfsHash}`;
 
 export default buildIpfsPath;

--- a/packages/prop-house-webapp/src/utils/getFirstImageFromProp.ts
+++ b/packages/prop-house-webapp/src/utils/getFirstImageFromProp.ts
@@ -15,7 +15,7 @@ const getFirstImageFromProp = async (proposal: StoredProposalWithVotes) => {
 
   // check if there's an image in the description or it is a ph pinata upload
   return (await isImage(match[1])) || match[1].includes('prophouse.mypinata')
-    ? match[1]
+    ? match[1].replace(/prophouse.mypinata.cloud/g, 'cloudflare-ipfs.com')
     : undefined;
 };
 


### PR DESCRIPTION
Pinata appears to have issues keeping track of our bandwidth usage. While they sort the issue out, we should switch to using Cloudflare's gateway instead.