### PR TITLE
Add img tag injection on proposal page

### DIFF
--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
@@ -80,8 +80,11 @@ const RenderedProposalFields: React.FC<RenderedProposalProps> = props => {
                   code: ['language-*', 'lang-*'],
                   pre: ['language-*', 'lang-*'],
                 },
+              })
                 // edge case: handle ampersands in img links encoded from sanitization
-              }).replaceAll('&amp;', '&')}
+                .replaceAll('&amp;', '&')
+                // Pinata requires crossorigin attribute on images
+                .replaceAll(/<img/g, '<img crossorigin="anonymous"')}
             </Markdown>
           </span>
         </Col>


### PR DESCRIPTION
The previous hotfix missed the Proposal page which uses a separate component than the proposal card. This hotfix addresses the Proposal page.