### PR TITLE
Start down rounds route

### DIFF
--- a/packages/prop-house-webapp/package.json
+++ b/packages/prop-house-webapp/package.json
@@ -43,6 +43,7 @@
     "moment": "^2.29.4",
     "papaparse": "^5.3.2",
     "quill-blot-formatter": "^1.0.5",
+    "ramda": "^0.29.0",
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.2",
     "react-countup": "^6.3.1",
@@ -96,6 +97,7 @@
   "devDependencies": {
     "@craco/craco": "^6.4.5",
     "@types/quill": "^2.0.9",
+    "@types/ramda": "^0.29.0",
     "@types/react-helmet": "^6.1.5",
     "react-scripts": "4.0.3"
   }

--- a/packages/prop-house-webapp/src/App.tsx
+++ b/packages/prop-house-webapp/src/App.tsx
@@ -30,6 +30,7 @@ import HouseManager from './pages/HouseManager';
 // import StatusRoundCards from './components/StatusRoundCards';
 import Rounds from './components/HouseManager/Rounds';
 import RoundCreatorProtectedRoute from './components/RoundCreatorProtectedRoute';
+import StatusRoundCards from './components/StatusRoundCards';
 
 const { chains, provider } = configureChains(
   [goerli],
@@ -87,7 +88,7 @@ function App() {
 
                   <Routes>
                     {/* TODO: Implement next */}
-                    {/* <Route path="/rounds" element={<StatusRoundCards />} /> */}
+                    <Route path="/rounds" element={<StatusRoundCards />} />
                     <Route path="/" element={<Home />} />
                     <Route
                       path="/create"

--- a/packages/prop-house-webapp/src/components/AcceptingPropsModule/index.tsx
+++ b/packages/prop-house-webapp/src/components/AcceptingPropsModule/index.tsx
@@ -14,7 +14,7 @@ import { useAppSelector } from '../../hooks';
 import { House, Round, RoundState } from '@prophouse/sdk-react';
 
 const AcceptingPropsModule: React.FC<{
-  round: Round
+  round: Round;
   community: House;
 }> = props => {
   const { round, community } = props;

--- a/packages/prop-house-webapp/src/components/StatusRoundCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/StatusRoundCard/index.tsx
@@ -1,282 +1,267 @@
-// import classes from './StatusRoundCard.module.css';
-// import Card, { CardBgColor, CardBorderRadius } from '../Card';
-// import clsx from 'clsx';
-// import { deadlineCopy, deadlineTime } from '../../utils/auctionStatus';
-// import { useNavigate } from 'react-router-dom';
-// import StatusPill from '../StatusPill';
-// import diffTime from '../../utils/diffTime';
-// import { useTranslation } from 'react-i18next';
-// import Tooltip from '../Tooltip';
-// import dayjs from 'dayjs';
-// import { cmdPlusClicked } from '../../utils/cmdPlusClicked';
-// import { openInNewTab } from '../../utils/openInNewTab';
-// import { useAppDispatch } from '../../hooks';
-// import { setActiveRound } from '../../state/slices/propHouse';
-// import TruncateThousands from '../TruncateThousands';
-// import { useEffect, useState } from 'react';
-// import { useAccount } from 'wagmi';
-// import Countdown from '../Countdown';
-// import { isInfAuction, isTimedAuction } from '../../utils/auctionType';
-// import { House, Round, RoundState, usePropHouse } from '@prophouse/sdk-react';
-// import { getDateFromTimestamp } from '../HouseManager/utils/getDateFromTimestamp';
+import classes from './StatusRoundCard.module.css';
+import Card, { CardBgColor, CardBorderRadius } from '../Card';
+import clsx from 'clsx';
+import { deadlineCopy, deadlineTime } from '../../utils/auctionStatus';
+import { useNavigate } from 'react-router-dom';
+import StatusPill from '../StatusPill';
+import diffTime from '../../utils/diffTime';
+import { useTranslation } from 'react-i18next';
+import Tooltip from '../Tooltip';
+import dayjs from 'dayjs';
+import { cmdPlusClicked } from '../../utils/cmdPlusClicked';
+import { openInNewTab } from '../../utils/openInNewTab';
+import { useAppDispatch } from '../../hooks';
+import { setActiveRound } from '../../state/slices/propHouse';
+import TruncateThousands from '../TruncateThousands';
+import { useEffect, useState } from 'react';
+import { useAccount } from 'wagmi';
+import Countdown from '../Countdown';
+import { isInfAuction, isTimedAuction } from '../../utils/auctionType';
+import { House, Round, RoundState, usePropHouse } from '@prophouse/sdk-react';
+import { getDateFromTimestamp } from '../HouseManager/utils/getDateFromTimestamp';
+import { useRoundDetails } from '../../hooks/useRoundDetails';
+import { roundCompleted } from '../../utils/sdk';
 
-// const StatusRoundCard: React.FC<{
-//   round: Round;
-// }> = props => {
-//   const { round } = props;
+const StatusRoundCard: React.FC<{
+  round: Round;
+}> = props => {
+  const { round } = props;
 
-//   const { t } = useTranslation();
+  const { t } = useTranslation();
 
-//   const [community, setCommunity] = useState<House | undefined>();
-//   const [numVotesCasted, setNumVotesCasted] = useState<number | undefined | null>(undefined);
-//   const [votingPower, setVotingPower] = useState<number | undefined | null>(undefined);
-//   const [statusCopy, setStatusCopy] = useState('...');
-//   const [numProps, setNumProps] = useState<number | undefined>(undefined);
-//   const [numVotes, setNumVotes] = useState<number | undefined>(undefined);
+  const propHouse = usePropHouse();
+  const [roundDetails] = useRoundDetails(propHouse, round.address);
+  //   const [numVotesCasted, setNumVotesCasted] = useState<number | undefined | null>(undefined);
+  //   const [votingPower, setVotingPower] = useState<number | undefined | null>(undefined);
+  //   const [statusCopy, setStatusCopy] = useState('...');
+  //   const [numProps, setNumProps] = useState<number | undefined>(undefined);
+  //   const [numVotes, setNumVotes] = useState<number | undefined>(undefined);
 
-//   let navigate = useNavigate();
-//   const dispatch = useAppDispatch();
+  let navigate = useNavigate();
+  const dispatch = useAppDispatch();
 
-//   const propHouse = usePropHouse();
+  const { address: account } = useAccount();
 
-//   const { address: account } = useAccount();
+  // timestamp to fetch latest prop/vote data (x votes/props y ago)
+  const dayAgo = dayjs().subtract(1, 'day').unix() * 1000;
+  const tenYearsAgo = dayjs().subtract(10, 'year').unix() * 1000;
 
-//   // timestamp to fetch latest prop/vote data (x votes/props y ago)
-//   const dayAgo = dayjs().subtract(1, 'day').unix() * 1000;
-//   const tenYearsAgo = dayjs().subtract(10, 'year').unix() * 1000;
+  //   // fetch num votes casted & voting power
+  //   useEffect(() => {
+  //     if (round?.state !== RoundState.IN_VOTING_PERIOD || !community) return;
+  //     if (!account) {
+  //       setVotingPower(null);
+  //       setNumVotesCasted(null);
+  //       return;
+  //     }
 
-//   // fetch num votes casted & voting power
-//   useEffect(() => {
-//     if (round?.state !== RoundState.IN_VOTING_PERIOD || !community) return;
-//     if (!account) {
-//       setVotingPower(null);
-//       setNumVotesCasted(null);
-//       return;
-//     }
+  //     const fetchVotesData = async () => {
+  //       try {
+  //         // TODO: Use localstorage
+  //         const numVotesCasted = await wrapper.getNumVotesCastedForRound(account, round.id);
 
-//     const fetchVotesData = async () => {
-//       try {
-//         // TODO: Use localstorage
-//         const numVotesCasted = await wrapper.getNumVotesCastedForRound(account, round.id);
+  //         const { votingStrategies } = await propHouse.query.getRoundVotingStrategies(round.address);
+  //         const votingPower = await propHouse.voting.getTotalVotingPower(
+  //           account,
+  //           round.config.proposalPeriodEndTimestamp,
+  //           votingStrategies,
+  //         );
 
-//         const { votingStrategies } = await propHouse.query.getRoundVotingStrategies(round.address);
-//         const votingPower = await propHouse.voting.getTotalVotingPower(
-//           account,
-//           round.config.proposalPeriodEndTimestamp,
-//           votingStrategies,
-//         );
+  //         // const votingPower = await getVotingPower(
+  //         //   account,
+  //         //   community.contractAddress,
+  //         //   new InfuraProvider(1, process.env.REACT_APP_INFURA_PROJECT_ID),
+  //         //   round.balanceBlockTag,
+  //         // );
+  //         setVotingPower(votingPower.toNumber()); // TODO: Support base units
+  //         setNumVotesCasted(numVotesCasted);
+  //       } catch (e) {
+  //         console.log('error fetching votes data: ', e);
+  //         setVotingPower(null);
+  //         setNumVotesCasted(null);
+  //       }
+  //     };
 
-//         // const votingPower = await getVotingPower(
-//         //   account,
-//         //   community.contractAddress,
-//         //   new InfuraProvider(1, process.env.REACT_APP_INFURA_PROJECT_ID),
-//         //   round.balanceBlockTag,
-//         // );
-//         setVotingPower(votingPower.toNumber()); // TODO: Support base units
-//         setNumVotesCasted(numVotesCasted);
-//       } catch (e) {
-//         console.log('error fetching votes data: ', e);
-//         setVotingPower(null);
-//         setNumVotesCasted(null);
-//       }
-//     };
+  //     fetchVotesData();
+  //   }, [setVotingPower, account, community, round, propHouse.query, propHouse.voting]);
 
-//     fetchVotesData();
-//   }, [setVotingPower, account, community, round, propHouse.query, propHouse.voting]);
+  //   // num votes
+  //   useEffect(() => {
+  //     if (round?.state < RoundState.IN_VOTING_PERIOD || (votingPower && votingPower > 0)) {
+  //       return;
+  //     }
 
-//   // num votes
-//   useEffect(() => {
-//     if (round?.state < RoundState.IN_VOTING_PERIOD || (votingPower && votingPower > 0)) {
-//       return;
-//     }
+  //     const fetchNumVotes = async () => {
+  //       const roundVotes = await propHouse.query.getVotes({
+  //         where: { round: '' } // TODO: Need to do source chain round
+  //       });
 
-//     const fetchNumVotes = async () => {
-//       const roundVotes = await propHouse.query.getVotes({
-//         where: { round: '' } // TODO: Need to do source chain round
-//       });
+  //       // const numVotes = await wrapper.getLatestNumVotes(
+  //       //   round.address,
+  //       //   auctionStatus(round) === AuctionStatus.AuctionEnded ? tenYearsAgo : dayAgo,
+  //       // );
+  //       setNumVotes(numVotes);
+  //     };
+  //     fetchNumVotes();
+  //   });
 
-//       // const numVotes = await wrapper.getLatestNumVotes(
-//       //   round.address,
-//       //   auctionStatus(round) === AuctionStatus.AuctionEnded ? tenYearsAgo : dayAgo,
-//       // );
-//       setNumVotes(numVotes);
-//     };
-//     fetchNumVotes();
-//   });
+  //   // num props
+  //   useEffect(() => {
+  //     if (round.state !== RoundState.IN_PROPOSING_PERIOD) return;
+  //     const fetchNumProps = async () => {
+  //       const numProps = await wrapper.getLatestNumProps(round.id, dayAgo);
+  //       setNumProps(numProps);
+  //     };
+  //     fetchNumProps();
+  //   });
 
-//   // num props
-//   useEffect(() => {
-//     if (round.state !== RoundState.IN_PROPOSING_PERIOD) return;
-//     const fetchNumProps = async () => {
-//       const numProps = await wrapper.getLatestNumProps(round.id, dayAgo);
-//       setNumProps(numProps);
-//     };
-//     fetchNumProps();
-//   });
+  //   // status bar copy
+  //   useEffect(() => {
+  //     // voting
+  //     if (round.state === RoundState.IN_VOTING_PERIOD) {
+  //       if (votingPower === undefined || numVotesCasted === undefined) return;
 
-//   // fetch community
-//   useEffect(() => {
-//     if (community !== undefined) return;
-//     const fetchCommunity = async () =>
-//       setCommunity(await wrapper.getCommunityWithId(round.communityId));
-//     fetchCommunity();
-//   });
+  //       if ((votingPower === null && numVotesCasted === null) || votingPower === 0)
+  //         setStatusCopy(`${numVotes} votes in the last 24 hrs`);
 
-//   // status bar copy
-//   useEffect(() => {
-//     // voting
-//     if (round.state === RoundState.IN_VOTING_PERIOD) {
-//       if (votingPower === undefined || numVotesCasted === undefined) return;
+  //       if (votingPower !== null && numVotesCasted !== null && votingPower > 0)
+  //         if (numVotesCasted === votingPower) {
+  //           setStatusCopy(`You casted all your ${votingPower} votes!`);
+  //         } else if (numVotesCasted > 0) {
+  //           setStatusCopy(`You casted ${numVotesCasted} of ${votingPower} votes`);
+  //         } else if (numVotesCasted === 0) {
+  //           setStatusCopy(`You haven't voted yet!`);
+  //         }
 
-//       if ((votingPower === null && numVotesCasted === null) || votingPower === 0)
-//         setStatusCopy(`${numVotes} votes in the last 24 hrs`);
+  //       // proposing
+  //     } else if (round.state === RoundState.IN_PROPOSING_PERIOD) {
+  //       if (numProps === undefined) return;
+  //       if (numProps === 0) {
+  //         setStatusCopy('No props in the last 24 hrs');
+  //       } else {
+  //         numProps &&
+  //           setStatusCopy(`${numProps} prop${numProps > 1 ? 's' : ''} submitted in the last 24 hrs`);
+  //       }
+  //     } else if (round.state === RoundState.NOT_STARTED) {
+  //       setStatusCopy(`Round set to begin in `);
+  //     } else if (round.state >= RoundState.IN_CLAIMING_PERIOD && numVotes) {
+  //       // TODO: More complex than this now
+  //       // const decimals = round.fundingAmount.toString().split('.')[1]?.length || 0;
 
-//       if (votingPower !== null && numVotesCasted !== null && votingPower > 0)
-//         if (numVotesCasted === votingPower) {
-//           setStatusCopy(`You casted all your ${votingPower} votes!`);
-//         } else if (numVotesCasted > 0) {
-//           setStatusCopy(`You casted ${numVotesCasted} of ${votingPower} votes`);
-//         } else if (numVotesCasted === 0) {
-//           setStatusCopy(`You haven't voted yet!`);
-//         }
+  //       // const amount = (round.fundingAmount * (isTimedAuction(round) ? round.numWinners : 1)).toFixed(
+  //       //   decimals,
+  //       // );
 
-//       // proposing
-//     } else if (round.state === RoundState.IN_PROPOSING_PERIOD) {
-//       if (numProps === undefined) return;
-//       if (numProps === 0) {
-//         setStatusCopy('No props in the last 24 hrs');
-//       } else {
-//         numProps &&
-//           setStatusCopy(`${numProps} prop${numProps > 1 ? 's' : ''} submitted in the last 24 hrs`);
-//       }
-//     } else if (round.state === RoundState.NOT_STARTED) {
-//       setStatusCopy(`Round set to begin in `);
-//     } else if (round.state >= RoundState.IN_CLAIMING_PERIOD && numVotes) {
-//       // TODO: More complex than this now
-//       // const decimals = round.fundingAmount.toString().split('.')[1]?.length || 0;
+  //       // setStatusCopy(
+  //       //   `${numVotes} votes awarded ${amount} ${round.currencyType} ${
+  //       //     isTimedAuction(round) && `to ${round.numWinners} builders`
+  //       //   }`,
+  //       // );
+  //     }
+  //   }, [votingPower, numVotesCasted, numProps, round, numVotes]);
 
-//       // const amount = (round.fundingAmount * (isTimedAuction(round) ? round.numWinners : 1)).toFixed(
-//       //   decimals,
-//       // );
+  return (
+    <>
+      <div
+        onClick={e => {
+          if (!roundDetails?.house.address) return;
+          dispatch(setActiveRound(round));
+          if (cmdPlusClicked(e)) {
+            openInNewTab(`${window.location.href}/${roundDetails.house.address}/${round.address}`);
+            return;
+          }
+          navigate(`../${roundDetails.house.address}/${round.address}`);
+        }}
+      >
+        <Card
+          bgColor={CardBgColor.White}
+          borderRadius={CardBorderRadius.twenty}
+          classNames={clsx(roundCompleted(round) && classes.roundEnded, classes.roundCard)}
+        >
+          <div className={classes.textContainer}>
+            <div className={classes.topContainer}>
+              <div className={classes.leftContainer}>
+                {roundDetails?.house && (
+                  <>
+                    <img src={roundDetails?.house.imageURI} alt="community profile" />
+                    <div>{roundDetails.house.name}</div>
+                  </>
+                )}
+              </div>
+              <StatusPill status={round.state} />
+            </div>
+            <div className={classes.authorContainer}>{round.title}</div>
+          </div>
+          {/* 
+          <div className={classes.roundInfo}>
+            <div className={clsx(classes.section, classes.funding)}>
+              <p className={classes.title}>{t('funding')}</p>
+              <p className={classes.info}>
+                <span className="">
+                  <TruncateThousands amount={round.fundingAmount} decimals={2} />
+                  {` ${round.currencyType}`}
+                </span>
+                {isTimedAuction(round) && (
+                  <>
+                    <span className={classes.xDivide}>{' × '}</span>
+                    <span className="">{round.config.winnerCount}</span>
+                  </>
+                )}
+              </p>
+            </div>
 
-//       // setStatusCopy(
-//       //   `${numVotes} votes awarded ${amount} ${round.currencyType} ${
-//       //     isTimedAuction(round) && `to ${round.numWinners} builders`
-//       //   }`,
-//       // );
-//     }
-//   }, [votingPower, numVotesCasted, numProps, round, numVotes]);
+            <div className={classes.divider}></div>
 
-//   return (
-//     <>
-//       <div
-//         onClick={e => {
-//           if (!community) return;
-//           dispatch(setActiveRound(round));
-//           if (cmdPlusClicked(e)) {
-//             openInNewTab(
-//               `${window.location.href}/${community.address}/${round.address}`,
-//             );
-//             return;
-//           }
-//           navigate(`../${community.address}/${round.address}`);
-//         }}
-//       >
-//         <Card
-//           bgColor={CardBgColor.White}
-//           borderRadius={CardBorderRadius.twenty}
-//           classNames={clsx(
-//             auctionStatus(round) === AuctionStatus.AuctionEnded && classes.roundEnded,
-//             classes.roundCard,
-//           )}
-//         >
-//           <div className={classes.textContainer}>
-//             <div className={classes.topContainer}>
-//               <div className={classes.leftContainer}>
-//                 {community && (
-//                   <>
-//                     <img src={community.profileImageUrl} alt="community profile" />
-//                     <div>{community.name}</div>
-//                   </>
-//                 )}
-//               </div>
-//               <StatusPill status={round.state} />
-//             </div>
-//             <div className={classes.authorContainer}>{round.title}</div>
-//           </div>
+            <div className={classes.section}>
+              <Tooltip
+                content={
+                  <>
+                    <p className={classes.title}>
+                      {isInfAuction(round) ? 'Quorum' : deadlineCopy(round)}
+                    </p>
+                    <p className={classes.info}>
+                      {isInfAuction(round)
+                        ? `${round.quorum * 100}%`
+                        : diffTime(deadlineTime(round)).replace('months', 'mos')}{' '}
+                    </p>
+                  </>
+                }
+                tooltipContent={
+                  isInfAuction(round)
+                    ? `The % of votes required for a prop to be funded`
+                    : `${dayjs(deadlineTime(round)).tz().format('MMMM D, YYYY h:mm A z')}`
+                }
+              />
+            </div>
 
-//           <div className={classes.roundInfo}>
-//             <div className={clsx(classes.section, classes.funding)}>
-//               <p className={classes.title}>{t('funding')}</p>
-//               <p className={classes.info}>
-//                 <span className="">
-//                   <TruncateThousands amount={round.fundingAmount} decimals={2} />
-//                   {` ${round.currencyType}`}
-//                 </span>
-//                 {isTimedAuction(round) && (
-//                   <>
-//                     <span className={classes.xDivide}>{' × '}</span>
-//                     <span className="">{round.config.winnerCount}</span>
-//                   </>
-//                 )}
-//               </p>
-//             </div>
+            <div className={clsx(classes.divider, classes.propSection)}></div>
 
-//             <div className={classes.divider}></div>
+            <div className={clsx(classes.section, classes.propSection)}>
+              <p className={classes.title}> {t('proposalsCap')}</p>
+              <p className={classes.info}>{round.numProposals}</p>
+            </div>
+          </div>
 
-//             <div className={classes.section}>
-//               <Tooltip
-//                 content={
-//                   <>
-//                     <p className={classes.title}>
-//                       {isInfAuction(round) ? 'Quorum' : deadlineCopy(round)}
-//                     </p>
-//                     <p className={classes.info}>
-//                       {isInfAuction(round)
-//                         ? `${round.quorum * 100}%`
-//                         : diffTime(deadlineTime(round)).replace('months', 'mos')}{' '}
-//                     </p>
-//                   </>
-//                 }
-//                 tooltipContent={
-//                   isInfAuction(round)
-//                     ? `The % of votes required for a prop to be funded`
-//                     : `${dayjs(deadlineTime(round)).tz().format('MMMM D, YYYY h:mm A z')}`
-//                 }
-//               />
-//             </div>
-
-//             <div className={clsx(classes.divider, classes.propSection)}></div>
-
-//             <div className={clsx(classes.section, classes.propSection)}>
-//               <p className={classes.title}> {t('proposalsCap')}</p>
-//               <p className={classes.info}>{round.numProposals}</p>
-//             </div>
-//           </div>
-
-//           <div
-//             className={clsx(
-//               classes.statusRow,
-//               round.state === RoundState.IN_VOTING_PERIOD
-//                 ? classes.voting
-//                 : round.state === RoundState.IN_PROPOSING_PERIOD
-//                 ? classes.proposing
-//                 : classes.notStartedOrEnded,
-//             )}
-//           >
-//             {round.state === RoundState.NOT_STARTED ? (
-//               <Countdown date={getDateFromTimestamp(round.config.proposalPeriodStartTimestamp)} />
-//             ) : (
-//               statusCopy
-//             )}
-//           </div>
-//         </Card>
-//       </div>
-//     </>
-//   );
-// };
-
-// TODO: Update this file
-const StatusRoundCard = () => <></>;
+          <div
+            className={clsx(
+              classes.statusRow,
+              round.state === RoundState.IN_VOTING_PERIOD
+                ? classes.voting
+                : round.state === RoundState.IN_PROPOSING_PERIOD
+                ? classes.proposing
+                : classes.notStartedOrEnded,
+            )}
+          >
+            {round.state === RoundState.NOT_STARTED ? (
+              <Countdown date={getDateFromTimestamp(round.config.proposalPeriodStartTimestamp)} />
+            ) : (
+              statusCopy
+            )}
+          </div> */}
+        </Card>
+      </div>
+    </>
+  );
+};
 
 export default StatusRoundCard;

--- a/packages/prop-house-webapp/src/components/StatusRoundCards/index.tsx
+++ b/packages/prop-house-webapp/src/components/StatusRoundCards/index.tsx
@@ -1,142 +1,137 @@
-// import classes from './StatusRoundCards.module.css';
-// import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
-// import { StoredAuctionBase } from '@nouns/prop-house-wrapper/dist/builders';
-// import { getRelevantComms } from 'prop-house-communities';
-// import { useEffect, useState } from 'react';
-// import { Col, Container, Navbar, Row } from 'react-bootstrap';
-// import { useAccount, useBlockNumber, useProvider } from 'wagmi';
-// import { useAppSelector } from '../../hooks';
-// import SimpleRoundCard from '../StatusRoundCard';
-// import { BiBadgeCheck } from 'react-icons/bi';
-// import LoadingIndicator from '../LoadingIndicator';
-// import InfiniteScroll from 'react-infinite-scroll-component';
+import classes from './StatusRoundCards.module.css';
+import { PropHouseWrapper } from '@nouns/prop-house-wrapper';
+import { StoredAuctionBase } from '@nouns/prop-house-wrapper/dist/builders';
+import { getRelevantComms } from 'prop-house-communities';
+import { useEffect, useState } from 'react';
+import { Col, Container, Navbar, Row } from 'react-bootstrap';
+import { useAccount, useBlockNumber, useProvider } from 'wagmi';
+import { useAppSelector } from '../../hooks';
+import SimpleRoundCard from '../StatusRoundCard';
+import { BiBadgeCheck } from 'react-icons/bi';
+import LoadingIndicator from '../LoadingIndicator';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import { usePropHouse } from '@prophouse/sdk-react';
+import { useRounds } from '../../hooks/useRounds';
+import { proposerSort } from '../../utils/sdk/sort';
 
-// const StatusRoundCards = () => {
-//   const { address: account } = useAccount();
-//   const { data: block } = useBlockNumber();
-//   const provider = useProvider();
-
-//   const QUERY_LIMIT = 8;
-//   const [fetchingRelComms, setFetchingRelComms] = useState(false);
-//   const [fetchingInitRounds, setFetchingInitRounds] = useState(false);
-//   const [hasMoreRounds, setHasMoreRounds] = useState(true);
-//   const [relevantCommunities, setRelevantCommunites] = useState<string[] | undefined>(undefined);
-//   const [rounds, setRounds] = useState<StoredAuctionBase[]>();
-//   const [roundsSkip, setRoundsSkip] = useState(0);
-
-//   const host = useAppSelector(state => state.configuration.backendHost);
-//   const wrapper = new PropHouseWrapper(host);
-
-//   useEffect(() => {
-//     if (relevantCommunities !== undefined || !block) return;
-
-//     const getRelComms = async () => {
-//       setFetchingRelComms(true);
-//       try {
-//         setRelevantCommunites(
-//           account ? Object.keys(await getRelevantComms(account, provider, block)) : [],
-//         );
-//       } catch (e) {
-//         console.log('Error fetching relevant comms: ', e);
-//         setRelevantCommunites([]);
-//       }
-//       setFetchingRelComms(false);
-//     };
-//     getRelComms();
-//   }, [block, relevantCommunities, account, provider]);
-
-//   useEffect(() => {
-//     if (rounds || fetchingRelComms || relevantCommunities === undefined) return;
-//     const getRounds = async () => {
-//       setFetchingInitRounds(true);
-//       try {
-//         relevantCommunities.length > 0
-//           ? setRounds(
-//               await wrapper.getActiveAuctionsForCommunities(
-//                 roundsSkip,
-//                 QUERY_LIMIT,
-//                 relevantCommunities,
-//               ),
-//             )
-//           : setRounds(await wrapper.getActiveAuctions(roundsSkip, QUERY_LIMIT));
-//         setRoundsSkip(QUERY_LIMIT);
-//       } catch (e) {
-//         console.log(e);
-//       }
-//       setFetchingInitRounds(false);
-//     };
-//     getRounds();
-//   });
-
-//   const fetchMoreRounds = async () => {
-//     let newRounds: StoredAuctionBase[];
-
-//     if (relevantCommunities && relevantCommunities.length > 0) {
-//       newRounds = await wrapper.getActiveAuctionsForCommunities(
-//         roundsSkip,
-//         QUERY_LIMIT,
-//         relevantCommunities,
-//       );
-//     } else {
-//       newRounds = await wrapper.getActiveAuctions(roundsSkip, QUERY_LIMIT);
-//     }
-
-//     if (newRounds.length === 0) {
-//       setHasMoreRounds(false);
-//       return;
-//     }
-
-//     setRounds(prev => {
-//       return !prev ? [...newRounds] : [...prev, ...newRounds];
-//     });
-//     setRoundsSkip(prev => prev + QUERY_LIMIT);
-//   };
-
-//   return (
-//     <>
-//       <Container>
-//         <Navbar />
-//       </Container>
-//       <Container>
-//         <Row>
-//           <Col>
-//             <div className={classes.sectionTitle}>
-//               <BiBadgeCheck className={classes.icon} size={22} />
-//               <>Active rounds</>
-//             </div>
-//           </Col>
-//         </Row>
-//         {fetchingRelComms || fetchingInitRounds ? (
-//           <LoadingIndicator />
-//         ) : (
-//           rounds && (
-//             <InfiniteScroll
-//               dataLength={rounds.length}
-//               next={fetchMoreRounds}
-//               hasMore={hasMoreRounds}
-//               loader={<LoadingIndicator />}
-//               endMessage={
-//                 <div className={classes.noMoreMsg}>
-//                   <>v nounish, ⌐◨-◨</>
-//                 </div>
-//               }
-//             >
-//               <Row>
-//                 {rounds.map(r => (
-//                   <Col md={6}>
-//                     <SimpleRoundCard round={r} />
-//                   </Col>
-//                 ))}
-//               </Row>
-//             </InfiniteScroll>
-//           )
-//         )}
-//       </Container>
-//     </>
-//   );
-// };
+const StatusRoundCards = () => {
+  const propHouse = usePropHouse();
+  const [activeRounds, refreshActiveRounds, loadingActiveRounds] = useRounds(propHouse);
+  //   const { address: account } = useAccount();
+  //   const { data: block } = useBlockNumber();
+  //   const provider = useProvider();
+  //   const QUERY_LIMIT = 8;
+  //   const [fetchingRelComms, setFetchingRelComms] = useState(false);
+  //   const [fetchingInitRounds, setFetchingInitRounds] = useState(false);
+  //   const [hasMoreRounds, setHasMoreRounds] = useState(true);
+  //   const [relevantCommunities, setRelevantCommunites] = useState<string[] | undefined>(undefined);
+  //   const [rounds, setRounds] = useState<StoredAuctionBase[]>();
+  //   const [roundsSkip, setRoundsSkip] = useState(0);
+  //   const host = useAppSelector(state => state.configuration.backendHost);
+  // const wrapper = new PropHouseWrapper(host);
+  //   useEffect(() => {
+  //     if (relevantCommunities !== undefined || !block) return;
+  //     const getRelComms = async () => {
+  //       setFetchingRelComms(true);
+  //       try {
+  //         setRelevantCommunites(
+  //           account ? Object.keys(await getRelevantComms(account, provider, block)) : [],
+  //         );
+  //       } catch (e) {
+  //         console.log('Error fetching relevant comms: ', e);
+  //         setRelevantCommunites([]);
+  //       }
+  //       setFetchingRelComms(false);
+  //     };
+  //     getRelComms();
+  //   }, [block, relevantCommunities, account, provider]);
+  //   useEffect(() => {
+  //     if (rounds || fetchingRelComms || relevantCommunities === undefined) return;
+  //     const getRounds = async () => {
+  //       setFetchingInitRounds(true);
+  //       try {
+  //         relevantCommunities.length > 0
+  //           ? setRounds(
+  //               await wrapper.getActiveAuctionsForCommunities(
+  //                 roundsSkip,
+  //                 QUERY_LIMIT,
+  //                 relevantCommunities,
+  //               ),
+  //             )
+  //           : setRounds(await wrapper.getActiveAuctions(roundsSkip, QUERY_LIMIT));
+  //         setRoundsSkip(QUERY_LIMIT);
+  //       } catch (e) {
+  //         console.log(e);
+  //       }
+  //       setFetchingInitRounds(false);
+  //     };
+  //     getRounds();
+  //   });
+  //   const fetchMoreRounds = async () => {
+  //     let newRounds: StoredAuctionBase[];
+  //     if (relevantCommunities && relevantCommunities.length > 0) {
+  //       newRounds = await wrapper.getActiveAuctionsForCommunities(
+  //         roundsSkip,
+  //         QUERY_LIMIT,
+  //         relevantCommunities,
+  //       );
+  //     } else {
+  //       newRounds = await wrapper.getActiveAuctions(roundsSkip, QUERY_LIMIT);
+  //     }
+  //     if (newRounds.length === 0) {
+  //       setHasMoreRounds(false);
+  //       return;
+  //     }
+  //     setRounds(prev => {
+  //       return !prev ? [...newRounds] : [...prev, ...newRounds];
+  //     });
+  //     setRoundsSkip(prev => prev + QUERY_LIMIT);
+  //   };
+  return (
+    <>
+      <Container>
+        <Navbar />
+      </Container>
+      <Container>
+        <Row>
+          <Col>
+            <div className={classes.sectionTitle}>
+              <BiBadgeCheck className={classes.icon} size={22} />
+              <>Active rounds</>
+            </div>
+          </Col>
+        </Row>
+        {loadingActiveRounds ? (
+          <LoadingIndicator />
+        ) : (
+          activeRounds && (
+            <InfiniteScroll
+              dataLength={activeRounds.length}
+              next={refreshActiveRounds}
+              hasMore={false}
+              loader={<LoadingIndicator />}
+              endMessage={
+                <div className={classes.noMoreMsg}>
+                  <>v nounish, ⌐◨-◨</>
+                </div>
+              }
+            >
+              <Row>
+                {proposerSort(activeRounds).map((r, i) => (
+                  <Col md={6} key={i}>
+                    <SimpleRoundCard round={r} />
+                  </Col>
+                ))}
+              </Row>
+            </InfiniteScroll>
+          )
+        )}
+      </Container>
+    </>
+  );
+};
 
 // TODO: Update this file
-const StatusRoundCards = () => <></>;
+// const StatusRoundCards = () => <></>;
 
 export default StatusRoundCards;

--- a/packages/prop-house-webapp/src/hooks/useRoundDetails.ts
+++ b/packages/prop-house-webapp/src/hooks/useRoundDetails.ts
@@ -1,0 +1,25 @@
+import { PropHouse, Round, RoundWithHouse } from '@prophouse/sdk-react';
+import { useEffect, useState } from 'react';
+import { activeTimedFundingRoundFilter } from '../utils/sdk';
+
+type Refresh = () => Promise<void>;
+export const useRoundDetails = (
+  propHouseProvider: PropHouse,
+  roundAddress: string,
+): [RoundWithHouse | undefined, Refresh, boolean] => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [roundDetails, setRoundDetails] = useState<RoundWithHouse | undefined>(undefined);
+
+  const fetchRoundDetails = async () => {
+    setLoading(true);
+    const round = await propHouseProvider.query.getRoundWithHouseInfo(roundAddress);
+    setRoundDetails(round);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchRoundDetails();
+  }, [roundAddress]);
+
+  return [roundDetails, fetchRoundDetails, loading];
+};

--- a/packages/prop-house-webapp/src/hooks/useRounds.ts
+++ b/packages/prop-house-webapp/src/hooks/useRounds.ts
@@ -1,0 +1,22 @@
+import { PropHouse, Round } from '@prophouse/sdk-react';
+import { useEffect, useState } from 'react';
+import { activeTimedFundingRoundFilter } from '../utils/sdk';
+
+type Refresh = () => Promise<void>;
+export const useRounds = (propHouseProvider: PropHouse): [Round[], Refresh, boolean] => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [activeRounds, setRounds] = useState<Round[]>([]);
+
+  const fetchRounds = async () => {
+    setLoading(true);
+    const rounds = await propHouseProvider.query.getRounds();
+    setRounds(rounds);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchRounds();
+  }, []);
+
+  return [activeRounds, fetchRounds, loading];
+};

--- a/packages/prop-house-webapp/src/utils/sdk/filter.ts
+++ b/packages/prop-house-webapp/src/utils/sdk/filter.ts
@@ -1,0 +1,24 @@
+import { RoundState } from '@prophouse/sdk-react';
+import filter from 'ramda/src/filter';
+import { RoundStatePartial } from './types';
+
+export const roundAllowsProposals = (round: RoundStatePartial) =>
+  round.state === RoundState.IN_PROPOSING_PERIOD;
+
+export const roundAllowsProposalsFilter = filter(roundAllowsProposals);
+
+export const roundAllowsVoting = (round: RoundStatePartial) =>
+  round.state === RoundState.IN_VOTING_PERIOD;
+
+export const roundAllowsVotingFilter = filter(roundAllowsVoting);
+
+export const roundAllowsClaiming = (round: RoundStatePartial) =>
+  round.state === RoundState.IN_CLAIMING_PERIOD;
+
+export const roundAllowsClaimingFilter = filter(roundAllowsClaiming);
+
+export const activeTimedFundingRoundFilter = filter(
+  (round: RoundStatePartial) => roundAllowsVoting(round) || roundAllowsProposals(round),
+);
+
+export const roundCompleted = (round: RoundStatePartial) => round.state === RoundState.COMPLETE;

--- a/packages/prop-house-webapp/src/utils/sdk/func.ts
+++ b/packages/prop-house-webapp/src/utils/sdk/func.ts
@@ -1,0 +1,7 @@
+export const allTrue = (pred: boolean[]) => pred.reduce((st, value) => st && value, true);
+
+export const anyTrue = (pred: boolean[]) => pred.reduce((st, value) => st || value, false);
+
+export const any = <T>(fn: (p: T) => boolean, data: T[]) => anyTrue(data.map(fn));
+
+export const all = <T>(fn: (p: T) => boolean, data: T[]) => allTrue(data.map(fn));

--- a/packages/prop-house-webapp/src/utils/sdk/index.ts
+++ b/packages/prop-house-webapp/src/utils/sdk/index.ts
@@ -1,0 +1,1 @@
+export * from './filter';

--- a/packages/prop-house-webapp/src/utils/sdk/sort.ts
+++ b/packages/prop-house-webapp/src/utils/sdk/sort.ts
@@ -1,0 +1,29 @@
+import { Round, RoundState } from '@prophouse/sdk-react';
+import { RoundStatePartial } from './types';
+
+export const proposerScore = (round: RoundStatePartial) => {
+  switch (round.state) {
+    case RoundState.AWAITING_REGISTRATION:
+      return 100;
+    case RoundState.NOT_STARTED:
+      return 150;
+    case RoundState.CANCELLED:
+    case RoundState.COMPLETE:
+      return 50;
+    case RoundState.IN_PROPOSING_PERIOD:
+      return 500;
+    case RoundState.IN_VOTING_PERIOD:
+      return 750;
+    case RoundState.IN_CLAIMING_PERIOD:
+      return 999;
+    case RoundState.UNKNOWN:
+      return 1;
+    default:
+      return 0;
+  }
+};
+
+export const proposerCompare = (a: RoundStatePartial, b: RoundStatePartial) =>
+  proposerScore(a) - proposerScore(b);
+
+export const proposerSort = (rounds: Round[]): Round[] => rounds.sort(proposerCompare);

--- a/packages/prop-house-webapp/src/utils/sdk/types.ts
+++ b/packages/prop-house-webapp/src/utils/sdk/types.ts
@@ -1,0 +1,4 @@
+import { RoundState } from '@prophouse/sdk-react';
+
+// TODO: clean once SDK types add state property to query response
+export type RoundStatePartial = { state: RoundState };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5479,6 +5479,13 @@
     parchment "^1.1.2"
     quill-delta "^4.0.1"
 
+"@types/ramda@^0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.29.0.tgz#4f226db24764dde77c60e1f601c357894bcfb7cc"
+  integrity sha512-TY9eKsklU43CmAbFJPKDUyBjleZ4EFAkbJeQRF4e8byGkOw1CjDcwg5EGa0Bgf0Kgs9BE9OU4UzQWnQDHnvMtA==
+  dependencies:
+    types-ramda "^0.29.1"
+
 "@types/range-parser@*":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
@@ -18240,6 +18247,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+ramda@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.29.0.tgz#fbbb67a740a754c8a4cbb41e2a6e0eb8507f55fb"
+  integrity sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -20994,6 +21006,11 @@ ts-pnp@1.2.0, ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+ts-toolbelt@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
+  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
+
 tsconfig-paths-webpack-plugin@3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
@@ -21181,6 +21198,13 @@ typeorm@^0.2.41:
     xml2js "^0.4.23"
     yargs "^17.0.1"
     zen-observable-ts "^1.0.0"
+
+types-ramda@^0.29.1:
+  version "0.29.1"
+  resolved "https://registry.yarnpkg.com/types-ramda/-/types-ramda-0.29.1.tgz#08c6ddf583ba359ec1113c7069e30a44ef73896d"
+  integrity sha512-pdEF8VXcBTSu3fPupZahieG6Lh8eBWPtcaH/OB5QPCoN2hz4vBbspoMLB3X9kwzXRD3lwD4/j0hwj3Z/PAzzcA==
+  dependencies:
+    ts-toolbelt "^9.6.0"
 
 typescript@4.3.5:
   version "4.3.5"


### PR DESCRIPTION
This may save a couple minutes of Soli time or can be tossed in the bin. The hooks and helper functions can be migrated to the `@prophouse/sdk-react` but looks like the latest wasn't pushed up at time of development and this addition had a dependency on status enum.