### PR TITLE
Fix Infinite Round Past Start Timestamp Bug

### DIFF
--- a/packages/prop-house-protocol/contracts/ethereum/rounds/InfiniteRound.sol
+++ b/packages/prop-house-protocol/contracts/ethereum/rounds/InfiniteRound.sol
@@ -238,8 +238,11 @@ contract InfiniteRound is IInfiniteRound, AssetRound {
     function _register(RoundConfig memory config) internal {
         _validate(config);
 
+        // Set the round start timestamp to the current block timestamp if it is in the past.
+        config.startTimestamp = _max(config.startTimestamp, uint40(block.timestamp));
+
         // Write round metadata to storage. This will be consumed by the token URI later.
-        startTimestamp = _max(config.startTimestamp, uint40(block.timestamp));
+        startTimestamp = config.startTimestamp;
         votePeriodDuration = config.votePeriodDuration;
 
         state = RoundState.Active;


### PR DESCRIPTION
Previously, we were only writing the output of `max(passed_start_timestamp, current_block_timestamp)` to the `startTimestamp` state variable. The value that was passed to Starknet could still be less than the current block timestamp. This could allow round creators to use past snapshots, or result in the round failing to deploy on Starknet if `0` was provided.

The fix is to write the output of `max` to `config.startTimestamp`.