### PR TITLE
Discord Bot Admin Expansion

### DIFF
--- a/packages/prop-house-backend/src/discord/discord.module.ts
+++ b/packages/prop-house-backend/src/discord/discord.module.ts
@@ -7,15 +7,18 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Proposal } from 'src/proposal/proposal.entity';
 import { InfiniteAuction } from 'src/infinite-auction/infinite-auction.entity';
 import { InfiniteAuctionService } from 'src/infinite-auction/infinite-auction.service';
+import { Auction } from 'src/auction/auction.entity';
+import { AuctionsService } from 'src/auction/auctions.service';
 
 @Module({
   controllers: [DiscordController],
-  imports: [TypeOrmModule.forFeature([Proposal, InfiniteAuction])],
+  imports: [TypeOrmModule.forFeature([Proposal, InfiniteAuction, Auction])],
   providers: [
     DiscordService,
     ProposalsService,
     ConfigService,
     InfiniteAuctionService,
+    AuctionsService
   ],
 })
 export class DiscordModule {}

--- a/packages/prop-house-backend/src/discord/discord.service.ts
+++ b/packages/prop-house-backend/src/discord/discord.service.ts
@@ -112,23 +112,29 @@ export class DiscordService {
 
         if (interaction.commandName === 'deleteprop') {
           // Check if admin of _any type_ to prevent DB strain
-          const isAdmin =
-            (interaction.member.roles as GuildMemberRoleManager).cache
-              .filter((r) => r.name.includes('prop-admin'))
-              .map((i) => i).length > 0;
-          if (!isAdmin) {
-            return interaction.reply("Sorry, you can't do that");
-          }
           const propId = interaction.options.getInteger('propid');
-          const proposal = await proposalsService.findOne(propId);
-          const auction = await auctionsService.findOne(proposal.auctionId)
-          const communityId = await auction.community
-          const isHouseAdmin =
+          const isSuperAdmin =
             (interaction.member.roles as GuildMemberRoleManager).cache
-              .filter((r) => r.name === `prop-admin-${communityId}`)
+              .filter((r) => r.name === `prop-superadmin`)
               .map((i) => i).length > 0;
-          if (!isHouseAdmin) {
-            return interaction.reply(`Sorry, you're not an admin for ${communityId}`);
+          if (!isSuperAdmin) {
+            const isAdmin =
+              (interaction.member.roles as GuildMemberRoleManager).cache
+                .filter((r) => r.name.includes('prop-admin'))
+                .map((i) => i).length > 0;
+            if (!isAdmin) {
+              return interaction.reply("Sorry, you can't do that");
+            }
+            const proposal = await proposalsService.findOne(propId);
+            const auction = await auctionsService.findOne(proposal.auctionId)
+            const communityId = await auction.community
+            const isHouseAdmin =
+              (interaction.member.roles as GuildMemberRoleManager).cache
+                .filter((r) => r.name === `prop-admin-${communityId}`)
+                .map((i) => i).length > 0;
+            if (!isHouseAdmin) {
+              return interaction.reply(`Sorry, you're not an admin for ${communityId}`);
+            }
           }
           try {
             await proposalsService.remove(propId);


### PR DESCRIPTION
This PR will consume generalized `prop-admin-<community id>` roles rather than only a single admin. This also adds the `prop-superadmin` role which can manage all houses.