### PR TITLE
Refactor ipfs rewrite, set image limit

### DIFF
--- a/packages/prop-house-webapp/package.json
+++ b/packages/prop-house-webapp/package.json
@@ -38,7 +38,9 @@
     "i18next-localstorage-backend": "^3.1.3",
     "is-image-url": "^1.1.8",
     "markdown-to-jsx": "^7.1.7",
+    "multiformats": "^12.1.0",
     "quill-blot-formatter": "^1.0.5",
+    "ramda": "^0.29.0",
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.2",
     "react-countup": "^6.3.1",
@@ -83,6 +85,7 @@
   },
   "devDependencies": {
     "@types/quill": "^2.0.9",
+    "@types/ramda": "^0.29.3",
     "@types/react-helmet": "^6.1.5"
   },
   "browserslist": [

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -30,6 +30,7 @@ import { isMobile } from 'web3modal';
 import ReplyBar from '../ReplyBar';
 import InfRoundVotingControls from '../InfRoundVotingControls';
 import TimedRoundVotingControls from '../TimedRoundVotingControls';
+import { replaceIpfsGateway } from '../../utils/ipfs';
 
 const ProposalCard: React.FC<{
   proposal: StoredProposalWithVotes;
@@ -128,7 +129,7 @@ const ProposalCard: React.FC<{
 
             {imgUrlFromProp && (
               <div className={classes.propImgContainer}>
-                <img src={imgUrlFromProp} crossOrigin="anonymous" alt="propCardImage" />
+                <img src={replaceIpfsGateway(imgUrlFromProp)} crossOrigin="anonymous" alt="propCardImage" />
               </div>
             )}
           </div>

--- a/packages/prop-house-webapp/src/components/ProposalContent/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalContent/index.tsx
@@ -4,6 +4,8 @@ import ReactMarkdown from 'react-markdown';
 import Markdown from 'markdown-to-jsx';
 import sanitizeHtml from 'sanitize-html';
 import { useTranslation } from 'react-i18next';
+import { pipe } from 'ramda';
+import { replaceIpfsGateway } from '../../utils/ipfs';
 
 export interface ProposalContentProps {
   fields: ProposalFields;
@@ -40,21 +42,25 @@ const ProposalContent: React.FC<ProposalContentProps> = props => {
            * <Markdown/> component used to render HTML, while supporting Markdown.
            */}
           <Markdown>
-            {sanitizeHtml(fields.what, {
-              allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-              allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(['data']),
-              allowedAttributes: {
-                img: ['src', 'alt', 'height', 'width'],
-                a: ['href', 'target'],
-              },
-              allowedClasses: {
-                code: ['language-*', 'lang-*'],
-                pre: ['language-*', 'lang-*'],
-              },
-              // edge case: handle ampersands in img links encoded from sanitization
-            })
-              .replaceAll('&amp;', '&')
-              .replaceAll(/<img/g, '<img crossorigin="anonymous"')}
+            {pipe(
+              (whatText: string) =>
+                sanitizeHtml(whatText, {
+                  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+                  allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(['data']),
+                  allowedAttributes: {
+                    img: ['src', 'alt', 'height', 'width'],
+                    a: ['href', 'target'],
+                  },
+                  allowedClasses: {
+                    code: ['language-*', 'lang-*'],
+                    pre: ['language-*', 'lang-*'],
+                  },
+                  // edge case: handle ampersands in img links encoded from sanitization
+                }),
+              (whatText: string) => whatText.replaceAll('&amp;', '&'),
+              (whatText: string) => whatText.replaceAll(/<img/g, '<img crossorigin="anonymous"'),
+              (whatText: string) => replaceIpfsGateway(whatText)
+            )(fields.what)}
           </Markdown>
         </span>
       </div>

--- a/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
+++ b/packages/prop-house-webapp/src/components/RenderedProposalFields/index.tsx
@@ -8,6 +8,8 @@ import sanitizeHtml from 'sanitize-html';
 import { useTranslation } from 'react-i18next';
 import { StoredAuctionBase, StoredProposal } from '@nouns/prop-house-wrapper/dist/builders';
 import { BiAward } from 'react-icons/bi';
+import { pipe } from 'ramda';
+import { replaceIpfsGateway } from '../../utils/ipfs';
 
 export interface RenderedProposalProps {
   proposal: StoredProposal;
@@ -67,22 +69,26 @@ const RenderedProposalFields: React.FC<RenderedProposalProps> = props => {
              * <Markdown/> component used to render HTML, while supporting Markdown.
              */}
             <Markdown>
-              {sanitizeHtml(fields.what, {
-                allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-                allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(['data']),
-                allowedAttributes: {
-                  img: ['src', 'alt', 'height', 'width'],
-                  a: ['href', 'target'],
-                },
-                allowedClasses: {
-                  code: ['language-*', 'lang-*'],
-                  pre: ['language-*', 'lang-*'],
-                },
-              })
+              {pipe(
+                (whatText: string) =>
+                  sanitizeHtml(whatText, {
+                    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+                    allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(['data']),
+                    allowedAttributes: {
+                      img: ['src', 'alt', 'height', 'width'],
+                      a: ['href', 'target'],
+                    },
+                    allowedClasses: {
+                      code: ['language-*', 'lang-*'],
+                      pre: ['language-*', 'lang-*'],
+                    },
+                  }),
                 // edge case: handle ampersands in img links encoded from sanitization
-                .replaceAll('&amp;', '&')
+                (whatText: string) => whatText.replaceAll('&amp;', '&'),
                 // Pinata requires crossorigin attribute on images
-                .replaceAll(/<img/g, '<img crossorigin="anonymous"')}
+                (whatText: string) => whatText.replaceAll(/<img/g, '<img crossorigin="anonymous"'),
+                (whatText: string) => replaceIpfsGateway(whatText),
+              )(fields.what)}
             </Markdown>
           </span>
         </Col>

--- a/packages/prop-house-webapp/src/utils/buildIpfsPath.ts
+++ b/packages/prop-house-webapp/src/utils/buildIpfsPath.ts
@@ -1,3 +1,6 @@
-const buildIpfsPath = (ipfsHash: string) => `https://prophouse.mypinata.cloud/ipfs/${ipfsHash}`;
+import { buildPhIpfsUrl } from './ipfs';
+
+const buildIpfsPath = (ipfsHash: string) =>
+  buildPhIpfsUrl({ cid: ipfsHash, fullIpfsPath: ipfsHash });
 
 export default buildIpfsPath;

--- a/packages/prop-house-webapp/src/utils/ipfs.ts
+++ b/packages/prop-house-webapp/src/utils/ipfs.ts
@@ -1,0 +1,43 @@
+import { CID } from 'multiformats/src/cid';
+import { base32 } from 'multiformats/src/bases/base32';
+
+interface IpfsImageSrcRegexMatch {
+  fullIpfsPath: string;
+  cid: string;
+  innerIpfsPath?: string;
+}
+
+export const ipfsImageSrcRegex =
+  /(ipfs:\/\/|https:\/\/prophouse.mypinata.cloud\/ipfs\/)(?<fullIpfsPath>(?<cid>[^/"'\s]*)((?<innerIpfsPath>[^"'\s]*))?)/g;
+
+export const replaceIpfsGateway = (text: string) => {
+  for (let match of text.matchAll(ipfsImageSrcRegex)) {
+    if (!match.groups?.cid) continue;
+    const newImgBody = buildHostedPinataIpfsUrl(match.groups as unknown as IpfsImageSrcRegexMatch);
+    text = text.replace(match[0], newImgBody);
+  }
+  return text;
+};
+
+export const buildPhIpfsUrl = (matchGroups: IpfsImageSrcRegexMatch) =>
+  `https://ipfs.backend.prop.house/ipfs/${matchGroups.fullIpfsPath}`;
+
+export const buildNftStorageUrl = (matchGroups: IpfsImageSrcRegexMatch) =>
+  `https://${ipfsIdtoV1(matchGroups.cid)}.ipfs.nftstorage.link/${matchGroups.innerIpfsPath || ''}`;
+
+export const buildDwebUrl = (matchGroups: IpfsImageSrcRegexMatch) =>
+  `https://${ipfsIdtoV1(matchGroups.cid)}.ipfs.dweb.link/${matchGroups.innerIpfsPath || ''}`;
+
+export const buildCloudflareIpfsUrl = (matchGroups: IpfsImageSrcRegexMatch) =>
+  `https://cloudflare-ipfs.com/ipfs/${matchGroups.fullIpfsPath}`;
+
+export const buildHostedPinataIpfsUrl = (matchGroups: IpfsImageSrcRegexMatch) =>
+  `https://prophouse.mypinata.cloud/ipfs/${matchGroups.fullIpfsPath}?img-width=930`;
+
+export const cidToV1 = (cid: string) => CID.parse(cid).toV1().toString(base32.encoder);
+
+/**
+ * Resolve an IPFS ID into a V1 CID. Supports both CIDv0 and CIDv1,
+ * and returns the original string if it is not a valid IPFS ID.
+ */
+export const ipfsIdtoV1 = (ipfsId: string) => (ipfsId[0] === 'Q' ? cidToV1(ipfsId) : ipfsId);

--- a/packages/prop-house-webapp/tsconfig.json
+++ b/packages/prop-house-webapp/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
+    "downlevelIteration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5351,6 +5351,13 @@
     parchment "^1.1.2"
     quill-delta "^4.0.1"
 
+"@types/ramda@^0.29.3":
+  version "0.29.3"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.29.3.tgz#6e4d4066df900a3456cf402bcef9b78b6990a754"
+  integrity sha512-Yh/RHkjN0ru6LVhSQtTkCRo6HXkfL9trot/2elzM/yXLJmbLm2v6kJc8yftTnwv1zvUob6TEtqI2cYjdqG3U0Q==
+  dependencies:
+    types-ramda "^0.29.4"
+
 "@types/range-parser@*":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
@@ -16134,6 +16141,11 @@ multicodec@^1.0.0, multicodec@^1.0.1:
     buffer "^5.6.0"
     varint "^5.0.0"
 
+multiformats@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-12.1.0.tgz#0c344239c7d8dc60c8079935b1dbb12e39d22214"
+  integrity sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==
+
 multiformats@^9.4.2:
   version "9.9.0"
   resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.9.0.tgz#c68354e7d21037a8f1f8833c8ccd68618e8f1d37"
@@ -18425,6 +18437,11 @@ raf@^3.4.1:
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
+
+ramda@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.29.0.tgz#fbbb67a740a754c8a4cbb41e2a6e0eb8507f55fb"
+  integrity sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
@@ -21174,6 +21191,11 @@ ts-pnp@1.2.0, ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+ts-toolbelt@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
+  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
+
 tsconfig-paths-webpack-plugin@3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
@@ -21366,6 +21388,13 @@ typeorm@^0.2.41:
     xml2js "^0.4.23"
     yargs "^17.0.1"
     zen-observable-ts "^1.0.0"
+
+types-ramda@^0.29.4:
+  version "0.29.4"
+  resolved "https://registry.yarnpkg.com/types-ramda/-/types-ramda-0.29.4.tgz#8d9b51df2e550a05cedab541cc75dcd72972c625"
+  integrity sha512-XO/820iRsCDwqLjE8XE+b57cVGPyk1h+U9lBGpDWvbEky+NQChvHVwaKM05WnW1c5z3EVQh8NhXFmh2E/1YazQ==
+  dependencies:
+    ts-toolbelt "^9.6.0"
 
 typescript@4.3.5:
   version "4.3.5"


### PR DESCRIPTION
This PR refactors IPFS gateway rewriting and also takes advantage of Pinata's [image opimization](https://docs.pinata.cloud/docs/image-optimizations) to set a maximum image size. Currently set to the max breakpoint width of the proposal body (~930px). Images larger than this size will be shrunk by Pinata and cached.