### PR TITLE
Fix inf round vote count

### DIFF
--- a/packages/prop-house-webapp/src/components/InfRoundVotingControls/index.tsx
+++ b/packages/prop-house-webapp/src/components/InfRoundVotingControls/index.tsx
@@ -25,12 +25,12 @@ const InfRoundVotingControls: React.FC<{
   const dispatch = useAppDispatch();
 
   const submittedUpVotesForProp = countNumVotesForPropWithDirection(
-    votesByUserInActiveRound,
+    proposal.votes,
     proposal.id,
     Direction.Up,
   );
   const submittedDownVotesForProp = countNumVotesForPropWithDirection(
-    votesByUserInActiveRound,
+    proposal.votes,
     proposal.id,
     Direction.Down,
   );

--- a/packages/prop-house-webapp/src/components/InfRoundVotingControls/index.tsx
+++ b/packages/prop-house-webapp/src/components/InfRoundVotingControls/index.tsx
@@ -53,7 +53,7 @@ const InfRoundVotingControls: React.FC<{
 
   // handles votes by clicking up/down arrows
   const handleClickVote = (e: any, direction: Direction) => {
-    if (!proposal || perPropVotesRemaining === 0) return;
+    if (!proposal || perPropVotesRemaining <= 0) return;
 
     e.stopPropagation();
 

--- a/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/ProposalCard/index.tsx
@@ -40,7 +40,7 @@ const ProposalCard: React.FC<{
   isWinner: boolean;
   stale?: boolean;
 }> = props => {
-  const { proposal, auctionStatus, cardStatus, isWinner, stale } = props;
+  const { proposal, auctionStatus, isWinner, stale } = props;
 
   const community = useAppSelector(state => state.propHouse.activeCommunity);
   const round = useAppSelector(state => state.propHouse.activeRound);


### PR DESCRIPTION
- Users were seeing only their own vote count during the voting state for inf round props
- This PR fixes it by displaying cumulative votes during voting for both voters and non-voters

Before:
<img width="653" alt="Screen Shot 2023-09-05 at 12 49 49 PM" src="https://github.com/Prop-House/prop-house-monorepo/assets/85328329/d1eee7d0-56d4-4c09-b4cd-1f55fd320482">

After:
<img width="584" alt="Screen Shot 2023-09-05 at 12 49 57 PM" src="https://github.com/Prop-House/prop-house-monorepo/assets/85328329/a450c086-0b08-4dca-83f8-f8bd0567eca8">
