### PR TITLE
Use prod env vars for offchain branch

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,8 @@
 [context.branch-deploy.environment]
     REACT_APP_NODE_ENV = "development"
 
+[context.offhcain]
+    REACT_APP_NODE_ENV = "production"
+
 [context.production.environment]
     REACT_APP_NODE_ENV = "production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 [context.branch-deploy.environment]
     REACT_APP_NODE_ENV = "development"
 
-[context.offhcain]
+[context.offhchain]
     REACT_APP_NODE_ENV = "production"
 
 [context.production.environment]


### PR DESCRIPTION
As we launch the onchain version of the app to prod (prop.house), we're going to continue to host the offchain version as offchain.prop.house. 

This PR would allow the `offchain` branch to work as prod and thus grab the necessary host vars to point to the production endpoints as opposed to the current dev endpoints.