### PR TITLE
Support NNS + ENS lookup of addresses

### DIFF
--- a/packages/prop-house-webapp/src/components/AddressAvatar/index.tsx
+++ b/packages/prop-house-webapp/src/components/AddressAvatar/index.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import classes from './AddressAvatar.module.css';
-import { useEnsAvatar, useEnsName } from 'wagmi';
+import { useEnsAvatar } from 'wagmi';
 import type { GlassesParts, GlassesBgColors } from '../../utils/getNoggles';
 import { Factory } from '@cloudnouns/factory';
 import NogglesData from './noggles.json';
 import clsx from 'clsx';
+import useNnsName from '../../hooks/useNnsName';
 
 const AddressAvatar: React.FC<{ address: string; size?: number }> = props => {
   const { address, size: s = 24 } = props;
 
-  const { data: ensName } = useEnsName({
+  const { data: ensName } = useNnsName({
     address: address as `0x${string}`,
   });
   const { data: avatar } = useEnsAvatar({ name: ensName });

--- a/packages/prop-house-webapp/src/components/Avatar/index.tsx
+++ b/packages/prop-house-webapp/src/components/Avatar/index.tsx
@@ -1,12 +1,13 @@
 import classes from './Avatar.module.css';
-import { useEnsAvatar, useEnsName } from 'wagmi';
+import { useEnsAvatar } from 'wagmi';
 import Jazzicon from 'react-jazzicon/dist/Jazzicon';
 import { jsNumberForAddress } from 'react-jazzicon';
+import useNnsName from '../../hooks/useNnsName';
 
 const Avatar: React.FC<{ address: string; diameter: number }> = props => {
   const { address, diameter } = props;
 
-  const { data: ensName } = useEnsName({
+  const { data: ensName } = useNnsName({
     address: address as `0x${string}`,
   });
   const { data: avatar } = useEnsAvatar({ name: ensName });

--- a/packages/prop-house-webapp/src/components/EthAddress/index.tsx
+++ b/packages/prop-house-webapp/src/components/EthAddress/index.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { useAppSelector } from '../../hooks';
 import trimEthAddress from '../../utils/trimEthAddress';
 import classes from './EthAddress.module.css';
-import { useEnsName } from 'wagmi';
 import Avatar from '../Avatar';
+import useNnsName from '../../hooks/useNnsName';
 
 const EthAddress: React.FC<{
   address: string;
@@ -19,8 +19,8 @@ const EthAddress: React.FC<{
   const etherscanHost = useAppSelector(state => state.configuration.etherscanHost);
   const buildAddressHref = (address: string) => [etherscanHost, 'address', address].join('/');
 
-  // wagmi hooks to get ENS name and avatar
-  const { data: ens } = useEnsName({ address: address as `0x${string}` });
+  // fetch NNS name falling back to their ENS name
+  const { data: ens } = useNnsName({ address: address as `0x${string}` });
 
   // trim address: 0x1234567890abcdef1234567890abcdef12345678 -> 0x1234...5678
   const shortAddress = trimEthAddress(address as string);

--- a/packages/prop-house-webapp/src/components/HouseManager/VoterCard/index.tsx
+++ b/packages/prop-house-webapp/src/components/HouseManager/VoterCard/index.tsx
@@ -1,13 +1,13 @@
 import classes from './VoterCard.module.css';
 import Text from '../Text';
 import AddressAvatar from '../../AddressAvatar';
-import { useEnsName } from 'wagmi';
 import trimEthAddress from '../../../utils/trimEthAddress';
 import { Asset, AssetType, VotingStrategyType } from '@prophouse/sdk-react';
 import { useEffect, useState } from 'react';
 import useAddressType from '../../../hooks/useAddressType';
 import useAssetImages from '../../../hooks/useAssetImages';
 import useAssetNames from '../../../hooks/useAssetNames';
+import useNnsName from '../../../hooks/useNnsName';
 
 const VoterCard: React.FC<{
   type: string;
@@ -17,7 +17,7 @@ const VoterCard: React.FC<{
 }> = props => {
   const { type, address, multiplier, tokenId } = props;
 
-  const { data: ens, isLoading } = useEnsName({ address: address as `0x${string}` });
+  const { data: ens, isLoading } = useNnsName({ address: address as `0x${string}` });
 
   // TODO: Refactor hack that takes NewVoter and converts it to an Asset to use available hooks
   const contractType = useAddressType(address);

--- a/packages/prop-house-webapp/src/hooks/useNnsName.ts
+++ b/packages/prop-house-webapp/src/hooks/useNnsName.ts
@@ -1,0 +1,31 @@
+import { Address } from 'viem';
+import { useContractRead } from 'wagmi';
+
+const nnsEnsReverseResolverAbi = [
+  {
+    inputs: [{ internalType: 'address', name: 'addr', type: 'address' }],
+    name: 'resolve',
+    outputs: [{ internalType: 'string', name: '', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+type FetchNnsNameArgs = {
+  /** Address to lookup */
+  address: Address;
+};
+type UseNnsNameArgs = Partial<FetchNnsNameArgs>;
+
+const useNnsName = (args: UseNnsNameArgs) => {
+  return useContractRead({
+    abi: nnsEnsReverseResolverAbi,
+    address: '0x849f92178950f6254db5d16d1ba265e70521ac1b',
+    enabled: Boolean(args.address),
+    functionName: 'resolve',
+    select: d => d as string | null,
+    args: [args.address],
+  });
+};
+
+export default useNnsName;


### PR DESCRIPTION
This PR adds support to NNS ([Nouns Naming Service](https://nns.xyz/)) to lookup addresses using the recommended method described in [this demo](https://github.com/apbigcod/nns-resolver-demo#looking-up---domains-from-an-address-with-eth-fallback-with-resolver-contract) by the NNS team.

### How

1. Added a new hook `useNnsName` which calls the method `resolve` in [0x849f92178950f6254db5d16d1ba265e70521ac1b](https://etherscan.io/address/0x849f92178950f6254db5d16d1ba265e70521ac1b) to do a reverse lookup on the NNS registry falling back to the ENS registry.
2. Replaced all uses of `useEnsName` with `useNnsName`

### Examples

<img width="312" alt="Screenshot 2024-01-07 at 19 46 53" src="https://github.com/Prop-House/prop-house-monorepo/assets/105980313/31f32e5f-f962-4da2-9d7f-1e6fd6aa3d42">
<img width="662" alt="Screenshot 2024-01-07 at 19 47 42" src="https://github.com/Prop-House/prop-house-monorepo/assets/105980313/217a626d-c36c-46f0-92fa-9fae8d034b5d">
